### PR TITLE
Attempt to fix Release workflow, part 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release.yml@latest
+    uses: mars/languages-github-actions/.github/workflows/_buildpacks-release.yml@patch-1
     with:
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
       dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
Revert "Set Release actions' runs-on & GH app token, to hopefully succeed with private repo. (#13)"

This reverts commit 29e47b790ef74429c9e680ed84d4c3563305a85a.

Also, switches to a patched version of this workflow that uses our private runners & Linguist GH app token.