### PR TITLE
Add heroku-static-web-server buildpack to the builder

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -41,8 +41,8 @@ export CR_PAT=XXXXX
 echo $CR_PAT | docker login ghcr.io -u mars --password-stdin
 
 # push the specific version
-docker tag frontend-web-builder ghcr.io/heroku/builder-test-public:frontend-web-builder-1.1.0_linux-arm64
-docker push ghcr.io/heroku/builder-test-public:frontend-web-builder-1.1.0_linux-arm64
+docker tag frontend-web-builder ghcr.io/heroku/builder-test-public:frontend-web-builder-1.1.1_linux-arm64
+docker push ghcr.io/heroku/builder-test-public:frontend-web-builder-1.1.1_linux-arm64
 
 # also push as "latest"
 docker tag frontend-web-builder ghcr.io/heroku/builder-test-public:frontend-web-builder-latest_linux-arm64

--- a/builder/README.md
+++ b/builder/README.md
@@ -28,6 +28,7 @@ Generate an internal preview builder for these buildpacks:
 cargo libcnb package --release --target aarch64-unknown-linux-musl
 pack buildpack package website --config packaged/aarch64-unknown-linux-musl/release/heroku_website/package.toml  --target "linux/arm64" --format file
 pack buildpack package website-nodejs --config packaged/aarch64-unknown-linux-musl/release/heroku_website-nodejs/package.toml  --target "linux/arm64" --format file
+pack buildpack package static-web-server --config packaged/aarch64-unknown-linux-musl/release/heroku_static-web-server/package.toml  --target "linux/arm64" --format file
 pack builder create frontend-web-builder --config builder/builder.toml --target "linux/arm64"
 ```
 
@@ -40,8 +41,8 @@ export CR_PAT=XXXXX
 echo $CR_PAT | docker login ghcr.io -u mars --password-stdin
 
 # push the specific version
-docker tag frontend-web-builder ghcr.io/heroku/builder-test-public:frontend-web-builder-1.0.2_linux-arm64
-docker push ghcr.io/heroku/builder-test-public:frontend-web-builder-1.0.2_linux-arm64
+docker tag frontend-web-builder ghcr.io/heroku/builder-test-public:frontend-web-builder-1.1.0_linux-arm64
+docker push ghcr.io/heroku/builder-test-public:frontend-web-builder-1.1.0_linux-arm64
 
 # also push as "latest"
 docker tag frontend-web-builder ghcr.io/heroku/builder-test-public:frontend-web-builder-latest_linux-arm64

--- a/builder/builder.toml
+++ b/builder/builder.toml
@@ -19,6 +19,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
   id = "heroku/website"
   uri = "../website.cnb"
 
+[[buildpacks]]
+  id = "heroku/static-web-server"
+  uri = "../static-web-server.cnb"
+
 [[order]]
   [[order.group]]
     id = "heroku/website-nodejs"

--- a/builder/builder.toml
+++ b/builder/builder.toml
@@ -26,9 +26,9 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
 [[order]]
   [[order.group]]
     id = "heroku/website-nodejs"
-    version = "1.0.2"
+    version = "1.1.1"
 
 [[order]]
   [[order.group]]
     id = "heroku/website"
-    version = "1.0.2"
+    version = "1.1.1"

--- a/meta-buildpacks/website-nodejs/buildpack.toml
+++ b/meta-buildpacks/website-nodejs/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "heroku/website-nodejs"
-version = "1.0.2"
+version = "1.1.1"
 name = "Heroku Website/Node.js"
 description = "Heroku's buildpack for static web apps that require Node.js for build."
 keywords = ["ember", "emberjs", "heroku"]
@@ -14,7 +14,7 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/release-phase"
-version = "1.0.1"
+version = "1.0.2"
 
 [[order.group]]
 id = "heroku/nodejs"

--- a/meta-buildpacks/website/buildpack.toml
+++ b/meta-buildpacks/website/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "heroku/website"
-version = "1.0.2"
+version = "1.1.1"
 name = "Heroku Website"
 description = "Heroku's buildpack for static websites."
 keywords = ["website", "html", "javascript", "css", "static", "heroku"]
@@ -14,7 +14,7 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/release-phase"
-version = "1.0.1"
+version = "1.0.2"
 
 [[order.group]]
 id = "heroku/static-web-server"


### PR DESCRIPTION
Attempting to support custom `heroku/static-web-server` usage, to document it in the [draft Dev Center article](https://salesforce.quip.com/CbNhACBH3NTB#temp:C:MTY9cba3a5e172541e4ae78c87ff).