### PR TITLE
Validate support for multi-architecture publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,11 @@ on:
 jobs:
   release:
     name: Release
-    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release.yml@latest
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release.yml@jwl/arch-specific-deps
     with:
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
       dry_run: ${{ inputs.dry_run }}
+      languages_cli_branch: "jwl/arch-specific-deps"
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
       cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
🛑 **Do not merge.** This branch is a temporary work-around for publishing.

Uses [jwl/arch-specific-deps branch](https://github.com/heroku/languages-github-actions/pull/272) of languages-github-actions release workflow.

To publish a release:
1. Prepare the release on `main`.
2. Rebase this branch on `main`.
3. Perform Release from this branch.