### PR TITLE
Update release-phase & nodejs buildpack versions

### DIFF
--- a/meta-buildpacks/website-nodejs/buildpack.toml
+++ b/meta-buildpacks/website-nodejs/buildpack.toml
@@ -14,11 +14,11 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/release-phase"
-version = "1.0.3"
+version = "1.0.4"
 
 [[order.group]]
 id = "heroku/nodejs"
-version = "3.3.5"
+version = "3.4.0"
 
 [[order.group]]
 id = "heroku/static-web-server"

--- a/meta-buildpacks/website-nodejs/package.toml
+++ b/meta-buildpacks/website-nodejs/package.toml
@@ -5,10 +5,10 @@ uri = "."
 uri = "libcnb:heroku/website-ember"
 
 [[dependencies]]
-uri = "docker://heroku/buildpack-nodejs:3.3.5"
+uri = "docker://heroku/buildpack-nodejs:3.4.0"
 
 [[dependencies]]
 uri = "libcnb:heroku/static-web-server"
 
 [[dependencies]]
-uri = "docker://heroku/buildpack-release-phase:1.0.3"
+uri = "docker://heroku/buildpack-release-phase:1.0.4"

--- a/meta-buildpacks/website/buildpack.toml
+++ b/meta-buildpacks/website/buildpack.toml
@@ -14,7 +14,7 @@ type = "MIT"
 
 [[order.group]]
 id = "heroku/release-phase"
-version = "1.0.3"
+version = "1.0.4"
 
 [[order.group]]
 id = "heroku/static-web-server"

--- a/meta-buildpacks/website/package.toml
+++ b/meta-buildpacks/website/package.toml
@@ -8,4 +8,4 @@ uri = "libcnb:heroku/website-public-html"
 uri = "libcnb:heroku/static-web-server"
 
 [[dependencies]]
-uri = "docker://heroku/buildpack-release-phase:1.0.3"
+uri = "docker://heroku/buildpack-release-phase:1.0.4"


### PR DESCRIPTION
This specifically pulls in the [release-phase fix](https://github.com/heroku/buildpacks-release-phase/releases/tag/v1.0.4) to ensure release logs are complete.