### PR TITLE
Update to Caddy 2.9.1

### DIFF
--- a/buildpacks/static-web-server/src/main.rs
+++ b/buildpacks/static-web-server/src/main.rs
@@ -27,7 +27,7 @@ use ureq as _;
 const BUILDPACK_NAME: &str = "Heroku Static Web Server Buildpack";
 const BUILD_PLAN_ID: &str = "static-web-server";
 const WEB_SERVER_NAME: &str = "caddy";
-const WEB_SERVER_VERSION: &str = "2.8.4";
+const WEB_SERVER_VERSION: &str = "2.9.1";
 
 pub(crate) struct StaticWebServerBuildpack;
 


### PR DESCRIPTION
> Looks like Caddy (our buildpack's web server) has [released significant versions](https://github.com/caddyserver/caddy/releases) since December. We should update the static-web-server buildpack from 2.8.4 to 2.9.1!  
—[Slack post](https://salesforce-internal.slack.com/archives/C07BQMS8EKD/p1739410276167689)