### PR TITLE
Update Node.js buildpack to 3.4.7

### DIFF
--- a/meta-buildpacks/website-nodejs/buildpack.toml
+++ b/meta-buildpacks/website-nodejs/buildpack.toml
@@ -18,7 +18,7 @@ version = "1.0.4"
 
 [[order.group]]
 id = "heroku/nodejs"
-version = "3.4.0"
+version = "3.4.7"
 
 [[order.group]]
 id = "heroku/static-web-server"

--- a/meta-buildpacks/website-nodejs/package.toml
+++ b/meta-buildpacks/website-nodejs/package.toml
@@ -5,7 +5,7 @@ uri = "."
 uri = "libcnb:heroku/website-ember"
 
 [[dependencies]]
-uri = "docker://heroku/buildpack-nodejs:3.4.0"
+uri = "docker://heroku/buildpack-nodejs:3.4.7"
 
 [[dependencies]]
 uri = "libcnb:heroku/static-web-server"


### PR DESCRIPTION
Update to [most recent Node.js CNB release](https://github.com/heroku/buildpacks-nodejs/releases/tag/v3.4.7).