### PR TITLE
Enhance 404 errors

### DIFF
--- a/buildpacks/static-web-server/README.md
+++ b/buildpacks/static-web-server/README.md
@@ -288,7 +288,7 @@ The 404 handler also accepts a path matcher (regex) to limit where the custom ha
 [com.heroku.static-web-server.errors.404]
 file_path = "index.html"
 status = 200
-path_regex = "^/app(/.*)?$" 
+path_exclusions = ["/assets/*", "/static/*"]
 ```
 
 ## Server-specific Configuration

--- a/buildpacks/static-web-server/README.md
+++ b/buildpacks/static-web-server/README.md
@@ -280,6 +280,17 @@ file_path = "index.html"
 status = 200
 ```
 
+#### 404 Handler Path Matching
+
+The 404 handler also accepts a path matcher (regex) to limit where the custom handler is applied, otherwise falling back to the generic 404 response,
+
+```toml
+[com.heroku.static-web-server.errors.404]
+file_path = "index.html"
+status = 200
+path_regex = "^/app(/.*)?$" 
+```
+
 ## Server-specific Configuration
 
 Beyond pure static website delivery, some use-cases require dynamic server-side capabilities. This buildpack offers some server-specific configuration options, which tie the app to the specific server. Currently, only one web server is implemented: [Caddy](https://caddyserver.com).

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -350,9 +350,18 @@ fn generate_error_404_route(
             "body": DEFAULT_404_HTML
         }]));
 
-    json!({
-        "handle": not_found_response_handlers
-    })
+    let path_regex = error_config.and_then(|ec| ec.path_regex.as_ref());
+
+    if let Some(pattern) = path_regex {
+        json!({
+            "match": [{"path_regexp": {"pattern": pattern}}],
+            "handle": not_found_response_handlers
+        })
+    } else {
+        json!({
+            "handle": not_found_response_handlers
+        })
+    }
 }
 
 const DEFAULT_404_HTML: &str = r#"
@@ -450,6 +459,7 @@ mod tests {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("error-404.html"),
                     status: None,
+                    path_regex: None,
                 }),
             }),
             ..HerokuWebServerConfig::default()
@@ -473,6 +483,7 @@ mod tests {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("index.html"),
                     status: Some(200),
+                    path_regex: None,
                 }),
             }),
             ..HerokuWebServerConfig::default()
@@ -483,6 +494,54 @@ mod tests {
         assert_eq!(
             route,
             json!({"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]})
+        );
+    }
+
+    #[test]
+    fn generates_custom_404_error_route_with_path_regex() {
+        let doc_root = String::from("tests/fixtures/client_side_routing/public");
+        let doc_index = "index.html".to_string();
+
+        let heroku_config = HerokuWebServerConfig {
+            errors: Some(ErrorsConfig {
+                custom_404_page: Some(ErrorConfig {
+                    file_path: PathBuf::from("index.html"),
+                    status: Some(200),
+                    path_regex: Some(r"^/app(/.*)?$".to_string()),
+                }),
+            }),
+            ..HerokuWebServerConfig::default()
+        };
+
+        let route = generate_error_404_route(&doc_root, &doc_index, heroku_config.errors.as_ref());
+
+        assert_eq!(
+            route,
+            json!({"match":[{"path_regexp":{"pattern":"^/app(/.*)?$"}}],"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]})
+        );
+    }
+
+    #[test]
+    fn generates_custom_404_error_route_with_negated_path_regex() {
+        let doc_root = String::from("tests/fixtures/client_side_routing/public");
+        let doc_index = "index.html".to_string();
+
+        let heroku_config = HerokuWebServerConfig {
+            errors: Some(ErrorsConfig {
+                custom_404_page: Some(ErrorConfig {
+                    file_path: PathBuf::from("index.html"),
+                    status: Some(200),
+                    path_regex: Some(r"^(?!/assets/)".to_string()),
+                }),
+            }),
+            ..HerokuWebServerConfig::default()
+        };
+
+        let route = generate_error_404_route(&doc_root, &doc_index, heroku_config.errors.as_ref());
+
+        assert_eq!(
+            route,
+            json!({"match":[{"path_regexp":{"pattern":"^(?!/assets/)"}}],"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]})
         );
     }
 

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -322,6 +322,15 @@ fn generate_error_404_route(
                     "uri": error_config.file_path,
                 },
                 {
+                    "handler": "headers",
+                    "response": {
+                        "set": {
+                            "Cache-Control": ["no-store, no-cache, must-revalidate"],
+                            "Pragma": ["no-cache"]
+                        }
+                    }
+                },
+                {
                     "handler": "file_server",
                     "root": doc_root,
                     "status_code": status_code,
@@ -334,7 +343,9 @@ fn generate_error_404_route(
             "handler": "static_response",
             "status_code": "404",
             "headers": {
-                "Content-Type": ["text/html"]
+                "Content-Type": ["text/html"],
+                "Cache-Control": ["no-store, no-cache, must-revalidate"],
+                "Pragma": ["no-cache"]
             },
             "body": DEFAULT_404_HTML
         }]));
@@ -448,7 +459,7 @@ mod tests {
 
         assert_eq!(
             route,
-            json!({"handle":[{"handler":"rewrite","uri":"error-404.html"},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/custom_errors/public","status_code":"404"}]})
+            json!({"handle":[{"handler":"rewrite","uri":"error-404.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/custom_errors/public","status_code":"404"}]})
         );
     }
 
@@ -471,7 +482,7 @@ mod tests {
 
         assert_eq!(
             route,
-            json!({"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]})
+            json!({"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]})
         );
     }
 

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -349,12 +349,12 @@ fn generate_error_404_route(
         "body": DEFAULT_404_HTML
     }]);
 
-    let path_regex = error_config.and_then(|ec| ec.path_regex.as_ref());
+    let path_exclusions = error_config.and_then(|ec| ec.path_exclusions.as_ref());
 
-    match (custom_handlers, path_regex) {
-        (Some(handlers), Some(pattern)) => vec![
+    match (custom_handlers, path_exclusions) {
+        (Some(handlers), Some(exclusions)) => vec![
             json!({
-                "match": [{"path_regexp": {"pattern": pattern}}],
+                "match": [{"not": [{"path": exclusions}]}],
                 "handle": handlers
             }),
             json!({
@@ -465,7 +465,7 @@ mod tests {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("error-404.html"),
                     status: None,
-                    path_regex: None,
+                    path_exclusions: None,
                 }),
             }),
             ..HerokuWebServerConfig::default()
@@ -491,7 +491,7 @@ mod tests {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("index.html"),
                     status: Some(200),
-                    path_regex: None,
+                    path_exclusions: None,
                 }),
             }),
             ..HerokuWebServerConfig::default()
@@ -508,7 +508,7 @@ mod tests {
     }
 
     #[test]
-    fn generates_custom_404_error_route_with_path_regex() {
+    fn generates_custom_404_error_route_with_path_exclusions() {
         let doc_root = String::from("tests/fixtures/client_side_routing/public");
         let doc_index = "index.html".to_string();
 
@@ -517,7 +517,7 @@ mod tests {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("index.html"),
                     status: Some(200),
-                    path_regex: Some(r"^/app(/.*)?$".to_string()),
+                    path_exclusions: Some(vec!["/assets/*".to_string()]),
                 }),
             }),
             ..HerokuWebServerConfig::default()
@@ -528,14 +528,14 @@ mod tests {
         assert_eq!(
             routes,
             vec![
-                json!({"match":[{"path_regexp":{"pattern":"^/app(/.*)?$"}}],"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]}),
+                json!({"match":[{"not":[{"path":["/assets/*"]}]}],"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]}),
                 json!({"handle":[{"body":"\n    <!DOCTYPE html>\n    <html lang=\"en\">\n    <head>\n        <meta charset=\"utf-8\">\n        <title>404 Not Found</title>\n    </head>\n    <body>\n        <h1>404 Not Found</h1>\n    </body>\n    </html>\n","handler":"static_response","headers":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Content-Type":["text/html"],"Pragma":["no-cache"]},"status_code":"404"}]})
             ]
         );
     }
 
     #[test]
-    fn generates_custom_404_error_route_with_negated_path_regex() {
+    fn generates_custom_404_error_route_with_multiple_path_exclusions() {
         let doc_root = String::from("tests/fixtures/client_side_routing/public");
         let doc_index = "index.html".to_string();
 
@@ -544,7 +544,10 @@ mod tests {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("index.html"),
                     status: Some(200),
-                    path_regex: Some(r"^(?!/assets/)".to_string()),
+                    path_exclusions: Some(vec![
+                        "/assets/*".to_string(),
+                        "/static/*".to_string(),
+                    ]),
                 }),
             }),
             ..HerokuWebServerConfig::default()
@@ -555,7 +558,7 @@ mod tests {
         assert_eq!(
             routes,
             vec![
-                json!({"match":[{"path_regexp":{"pattern":"^(?!/assets/)"}}],"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]}),
+                json!({"match":[{"not":[{"path":["/assets/*","/static/*"]}]}],"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]}),
                 json!({"handle":[{"body":"\n    <!DOCTYPE html>\n    <html lang=\"en\">\n    <head>\n        <meta charset=\"utf-8\">\n        <title>404 Not Found</title>\n    </head>\n    <body>\n        <h1>404 Not Found</h1>\n    </body>\n    </html>\n","handler":"static_response","headers":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Content-Type":["text/html"],"Pragma":["no-cache"]},"status_code":"404"}]})
             ]
         );

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -544,10 +544,7 @@ mod tests {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("index.html"),
                     status: Some(200),
-                    path_exclusions: Some(vec![
-                        "/assets/*".to_string(),
-                        "/static/*".to_string(),
-                    ]),
+                    path_exclusions: Some(vec!["/assets/*".to_string(), "/static/*".to_string()]),
                 }),
             }),
             ..HerokuWebServerConfig::default()

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -132,7 +132,7 @@ pub(crate) fn caddy_json_config(
         "handle": static_file_handlers
     }));
 
-    routes.push(generate_error_404_route(
+    routes.extend(generate_error_404_route(
         &doc_root,
         &doc_index,
         config.errors.as_ref(),
@@ -303,64 +303,70 @@ fn generate_error_404_route(
     doc_root: &str,
     doc_index: &str,
     errors: Option<&ErrorsConfig>,
-) -> serde_json::Value {
+) -> Vec<serde_json::Value> {
     let error_config = errors.and_then(|errors| errors.custom_404_page.as_ref());
 
-    let not_found_response_handlers = error_config
-        .map(|error_config| {
-            let status_code = error_config.status.unwrap_or(404).to_string();
-            tracing::info!(
-                { CONFIG_ERROR_404_FILE_PATH } =
-                    error_config.file_path.to_string_lossy().to_string(),
-                "config"
-            );
-            tracing::info!({ CONFIG_ERROR_404_STATUS_CODE } = status_code, "config");
+    let custom_handlers = error_config.map(|error_config| {
+        let status_code = error_config.status.unwrap_or(404).to_string();
+        tracing::info!(
+            { CONFIG_ERROR_404_FILE_PATH } = error_config.file_path.to_string_lossy().to_string(),
+            "config"
+        );
+        tracing::info!({ CONFIG_ERROR_404_STATUS_CODE } = status_code, "config");
 
-            json!([
-                {
-                    "handler": "rewrite",
-                    "uri": error_config.file_path,
-                },
-                {
-                    "handler": "headers",
-                    "response": {
-                        "set": {
-                            "Cache-Control": ["no-store, no-cache, must-revalidate"],
-                            "Pragma": ["no-cache"]
-                        }
-                    }
-                },
-                {
-                    "handler": "file_server",
-                    "root": doc_root,
-                    "status_code": status_code,
-                    "index_names": vec![doc_index],
-                    "pass_thru": false
-                }
-            ])
-        })
-        .unwrap_or(json!([{
-            "handler": "static_response",
-            "status_code": "404",
-            "headers": {
-                "Content-Type": ["text/html"],
-                "Cache-Control": ["no-store, no-cache, must-revalidate"],
-                "Pragma": ["no-cache"]
+        json!([
+            {
+                "handler": "rewrite",
+                "uri": error_config.file_path,
             },
-            "body": DEFAULT_404_HTML
-        }]));
+            {
+                "handler": "headers",
+                "response": {
+                    "set": {
+                        "Cache-Control": ["no-store, no-cache, must-revalidate"],
+                        "Pragma": ["no-cache"]
+                    }
+                }
+            },
+            {
+                "handler": "file_server",
+                "root": doc_root,
+                "status_code": status_code,
+                "index_names": vec![doc_index],
+                "pass_thru": false
+            }
+        ])
+    });
+
+    let default_handlers = json!([{
+        "handler": "static_response",
+        "status_code": "404",
+        "headers": {
+            "Content-Type": ["text/html"],
+            "Cache-Control": ["no-store, no-cache, must-revalidate"],
+            "Pragma": ["no-cache"]
+        },
+        "body": DEFAULT_404_HTML
+    }]);
 
     let path_regex = error_config.and_then(|ec| ec.path_regex.as_ref());
 
-    if let Some(pattern) = path_regex {
-        json!({
-            "match": [{"path_regexp": {"pattern": pattern}}],
-            "handle": not_found_response_handlers
-        })
-    } else {
-        json!({
-            "handle": not_found_response_handlers
-        })
+    match (custom_handlers, path_regex) {
+        (Some(handlers), Some(pattern)) => vec![
+            json!({
+                "match": [{"path_regexp": {"pattern": pattern}}],
+                "handle": handlers
+            }),
+            json!({
+                "handle": default_handlers
+            }),
+        ],
+        (Some(handlers), None) => vec![json!({
+            "handle": handlers
+        })],
+        _ => vec![json!({
+            "handle": default_handlers
+        })],
     }
 }
 
@@ -465,11 +471,13 @@ mod tests {
             ..HerokuWebServerConfig::default()
         };
 
-        let route = generate_error_404_route(&doc_root, &doc_index, heroku_config.errors.as_ref());
+        let routes = generate_error_404_route(&doc_root, &doc_index, heroku_config.errors.as_ref());
 
         assert_eq!(
-            route,
-            json!({"handle":[{"handler":"rewrite","uri":"error-404.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/custom_errors/public","status_code":"404"}]})
+            routes,
+            vec![
+                json!({"handle":[{"handler":"rewrite","uri":"error-404.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/custom_errors/public","status_code":"404"}]})
+            ]
         );
     }
 
@@ -489,11 +497,13 @@ mod tests {
             ..HerokuWebServerConfig::default()
         };
 
-        let route = generate_error_404_route(&doc_root, &doc_index, heroku_config.errors.as_ref());
+        let routes = generate_error_404_route(&doc_root, &doc_index, heroku_config.errors.as_ref());
 
         assert_eq!(
-            route,
-            json!({"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]})
+            routes,
+            vec![
+                json!({"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]})
+            ]
         );
     }
 
@@ -513,11 +523,14 @@ mod tests {
             ..HerokuWebServerConfig::default()
         };
 
-        let route = generate_error_404_route(&doc_root, &doc_index, heroku_config.errors.as_ref());
+        let routes = generate_error_404_route(&doc_root, &doc_index, heroku_config.errors.as_ref());
 
         assert_eq!(
-            route,
-            json!({"match":[{"path_regexp":{"pattern":"^/app(/.*)?$"}}],"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]})
+            routes,
+            vec![
+                json!({"match":[{"path_regexp":{"pattern":"^/app(/.*)?$"}}],"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]}),
+                json!({"handle":[{"body":"\n    <!DOCTYPE html>\n    <html lang=\"en\">\n    <head>\n        <meta charset=\"utf-8\">\n        <title>404 Not Found</title>\n    </head>\n    <body>\n        <h1>404 Not Found</h1>\n    </body>\n    </html>\n","handler":"static_response","headers":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Content-Type":["text/html"],"Pragma":["no-cache"]},"status_code":"404"}]})
+            ]
         );
     }
 
@@ -537,11 +550,14 @@ mod tests {
             ..HerokuWebServerConfig::default()
         };
 
-        let route = generate_error_404_route(&doc_root, &doc_index, heroku_config.errors.as_ref());
+        let routes = generate_error_404_route(&doc_root, &doc_index, heroku_config.errors.as_ref());
 
         assert_eq!(
-            route,
-            json!({"match":[{"path_regexp":{"pattern":"^(?!/assets/)"}}],"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]})
+            routes,
+            vec![
+                json!({"match":[{"path_regexp":{"pattern":"^(?!/assets/)"}}],"handle":[{"handler":"rewrite","uri":"index.html"},{"handler":"headers","response":{"set":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Pragma":["no-cache"]}}},{"handler":"file_server","index_names":["index.html"],"pass_thru":false,"root":"tests/fixtures/client_side_routing/public","status_code":"200"}]}),
+                json!({"handle":[{"body":"\n    <!DOCTYPE html>\n    <html lang=\"en\">\n    <head>\n        <meta charset=\"utf-8\">\n        <title>404 Not Found</title>\n    </head>\n    <body>\n        <h1>404 Not Found</h1>\n    </body>\n    </html>\n","handler":"static_response","headers":{"Cache-Control":["no-store, no-cache, must-revalidate"],"Content-Type":["text/html"],"Pragma":["no-cache"]},"status_code":"404"}]})
+            ]
         );
     }
 

--- a/buildpacks/static-web-server/src/heroku_web_server_config.rs
+++ b/buildpacks/static-web-server/src/heroku_web_server_config.rs
@@ -210,10 +210,7 @@ mod tests {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("index.html"),
                     status: Some(200),
-                    path_exclusions: Some(vec![
-                        "/assets/*".to_string(),
-                        "/static/*".to_string()
-                    ]),
+                    path_exclusions: Some(vec!["/assets/*".to_string(), "/static/*".to_string()]),
                 }),
             })
         );

--- a/buildpacks/static-web-server/src/heroku_web_server_config.rs
+++ b/buildpacks/static-web-server/src/heroku_web_server_config.rs
@@ -29,7 +29,7 @@ pub(crate) struct ErrorsConfig {
 pub(crate) struct ErrorConfig {
     pub(crate) file_path: PathBuf,
     pub(crate) status: Option<u16>,
-    pub(crate) path_regex: Option<String>,
+    pub(crate) path_exclusions: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Eq, PartialEq, Debug, Default, Clone)]
@@ -188,29 +188,32 @@ mod tests {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("error-404.html"),
                     status: None,
-                    path_regex: None,
+                    path_exclusions: None,
                 }),
             })
         );
     }
 
     #[test]
-    fn custom_errors_with_path_regex() {
-        let toml_config = toml! {
+    fn custom_errors_with_path_exclusions() {
+        let toml_str = r#"
             [errors]
             404.file_path = "index.html"
             404.status = 200
-            404.path_regex = "^/app(/.*)?$"
-        };
+            404.path_exclusions = ["/assets/*", "/static/*"]
+        "#;
 
-        let parsed_config = toml_config.try_into::<HerokuWebServerConfig>().unwrap();
+        let parsed_config: HerokuWebServerConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(
             parsed_config.errors,
             Some(ErrorsConfig {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("index.html"),
                     status: Some(200),
-                    path_regex: Some(r"^/app(/.*)?$".to_string()),
+                    path_exclusions: Some(vec![
+                        "/assets/*".to_string(),
+                        "/static/*".to_string()
+                    ]),
                 }),
             })
         );

--- a/buildpacks/static-web-server/src/heroku_web_server_config.rs
+++ b/buildpacks/static-web-server/src/heroku_web_server_config.rs
@@ -29,6 +29,7 @@ pub(crate) struct ErrorsConfig {
 pub(crate) struct ErrorConfig {
     pub(crate) file_path: PathBuf,
     pub(crate) status: Option<u16>,
+    pub(crate) path_regex: Option<String>,
 }
 
 #[derive(Deserialize, Eq, PartialEq, Debug, Default, Clone)]
@@ -187,7 +188,30 @@ mod tests {
                 custom_404_page: Some(ErrorConfig {
                     file_path: PathBuf::from("error-404.html"),
                     status: None,
-                })
+                    path_regex: None,
+                }),
+            })
+        );
+    }
+
+    #[test]
+    fn custom_errors_with_path_regex() {
+        let toml_config = toml! {
+            [errors]
+            404.file_path = "index.html"
+            404.status = 200
+            404.path_regex = "^/app(/.*)?$"
+        };
+
+        let parsed_config = toml_config.try_into::<HerokuWebServerConfig>().unwrap();
+        assert_eq!(
+            parsed_config.errors,
+            Some(ErrorsConfig {
+                custom_404_page: Some(ErrorConfig {
+                    file_path: PathBuf::from("index.html"),
+                    status: Some(200),
+                    path_regex: Some(r"^/app(/.*)?$".to_string()),
+                }),
             })
         );
     }

--- a/buildpacks/static-web-server/tests/fixtures/custom_errors/project.toml
+++ b/buildpacks/static-web-server/tests/fixtures/custom_errors/project.toml
@@ -1,2 +1,3 @@
 [com.heroku.static-web-server.errors.404]
 file_path = "error-404.html"
+path_exclusions = ["/assets/*"]

--- a/buildpacks/static-web-server/tests/integration_test.rs
+++ b/buildpacks/static-web-server/tests/integration_test.rs
@@ -200,7 +200,6 @@ fn custom_headers() {
 }
 
 #[test]
-#[ignore = "integration test"]
 fn custom_errors() {
     static_web_server_integration_test("./fixtures/custom_errors", |ctx| {
         assert_contains!(ctx.pack_stdout, "Static Web Server");
@@ -224,6 +223,29 @@ fn custom_errors() {
                             assert_contains!(h, "text/html");
                             let response_body = response.into_string().unwrap();
                             assert_contains!(response_body, "Custom 404");
+                        }
+                        error @ ureq::Error::Transport(_) => {
+                            panic!("should respond 404 Not Found, but got other error: {error:?}");
+                        }
+                    },
+                }
+                let response_result_from_negated_path_regexp =
+                    retry(DEFAULT_RETRIES, DEFAULT_RETRY_DELAY, || {
+                        ureq::get(&format!("http://{socket_addr}/assets/non-existent-path"))
+                            .call()
+                            .map_err(Box::new)
+                    });
+                match response_result_from_negated_path_regexp {
+                    Ok(_) => {
+                        panic!("should respond 404 Not Found, but got 200 ok");
+                    }
+                    Err(err) => match *err {
+                        ureq::Error::Status(code, response) => {
+                            assert_eq!(code, 404);
+                            let h = response.header("Content-Type").unwrap_or_default();
+                            assert_contains!(h, "text/html");
+                            let response_body = response.into_string().unwrap();
+                            assert_contains!(response_body, "404 Not Found");
                         }
                         error @ ureq::Error::Transport(_) => {
                             panic!("should respond 404 Not Found, but got other error: {error:?}");

--- a/buildpacks/static-web-server/tests/integration_test.rs
+++ b/buildpacks/static-web-server/tests/integration_test.rs
@@ -200,6 +200,7 @@ fn custom_headers() {
 }
 
 #[test]
+#[ignore = "integration test"]
 fn custom_errors() {
     static_web_server_integration_test("./fixtures/custom_errors", |ctx| {
         assert_contains!(ctx.pack_stdout, "Static Web Server");


### PR DESCRIPTION
- Added a `headers` handler in the custom and default not found error route; sets `Cache-Control: no-store, no-cache, must-revalidate` and `Pragma: no-cache` to prevent browsers and intermediaries from caching error responses.
- Added a `path_exclusions` option to custom not found error config ([docs](https://github.com/heroku/buildpacks-frontend-web/blob/026a69e4fbe693994ebf21e26d9041248a5c4479/buildpacks/static-web-server/README.md#404-handler-path-matching))