### PR TITLE
Report config toggle metrics when disabled

### DIFF
--- a/buildpacks/static-web-server/CHANGELOG.md
+++ b/buildpacks/static-web-server/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report the `cnb.static-web-server.config.caddy_server_opts_templates` metric with its actual boolean value, so disabled templates emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.caddy_server_opts_clean_urls` metric with its actual boolean value, so disabled clean URLs emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.caddy_server_opts_access_logs` metric with its actual boolean value, so disabled access logs emits `false` instead of being omitted.
+- Report the `cnb.static-web-server.config.response_headers_enabled` metric on every build, emitting `false` when no response headers are configured instead of being omitted.
 
 ## [3.3.1] - 2026-05-29
 

--- a/buildpacks/static-web-server/CHANGELOG.md
+++ b/buildpacks/static-web-server/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Report the `cnb.static-web-server.config.runtime_config_enabled` metric with its actual boolean value, so a disabled runtime config emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.caddy_server_opts_basic_auth` metric with its actual boolean value, so disabled basic auth emits `false` instead of being omitted.
+- Report the `cnb.static-web-server.config.caddy_server_opts_templates` metric with its actual boolean value, so disabled templates emits `false` instead of being omitted.
 
 ## [3.3.1] - 2026-05-29
 

--- a/buildpacks/static-web-server/CHANGELOG.md
+++ b/buildpacks/static-web-server/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Report the `cnb.static-web-server.config.runtime_config_enabled` metric with its actual boolean value, so a disabled runtime config emits `false` instead of being omitted.
+
 ## [3.3.1] - 2026-05-29
 
 - Update Caddy web server version to 2.11.3.

--- a/buildpacks/static-web-server/CHANGELOG.md
+++ b/buildpacks/static-web-server/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Report the `cnb.static-web-server.config.runtime_config_enabled` metric with its actual boolean value, so a disabled runtime config emits `false` instead of being omitted.
+- Report the `cnb.static-web-server.config.caddy_server_opts_basic_auth` metric with its actual boolean value, so disabled basic auth emits `false` instead of being omitted.
 
 ## [3.3.1] - 2026-05-29
 

--- a/buildpacks/static-web-server/CHANGELOG.md
+++ b/buildpacks/static-web-server/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report the `cnb.static-web-server.config.caddy_server_opts_basic_auth` metric with its actual boolean value, so disabled basic auth emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.caddy_server_opts_templates` metric with its actual boolean value, so disabled templates emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.caddy_server_opts_clean_urls` metric with its actual boolean value, so disabled clean URLs emits `false` instead of being omitted.
+- Report the `cnb.static-web-server.config.caddy_server_opts_access_logs` metric with its actual boolean value, so disabled access logs emits `false` instead of being omitted.
 
 ## [3.3.1] - 2026-05-29
 

--- a/buildpacks/static-web-server/CHANGELOG.md
+++ b/buildpacks/static-web-server/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report the `cnb.static-web-server.config.runtime_config_enabled` metric with its actual boolean value, so a disabled runtime config emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.caddy_server_opts_basic_auth` metric with its actual boolean value, so disabled basic auth emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.caddy_server_opts_templates` metric with its actual boolean value, so disabled templates emits `false` instead of being omitted.
+- Report the `cnb.static-web-server.config.caddy_server_opts_clean_urls` metric with its actual boolean value, so disabled clean URLs emits `false` instead of being omitted.
 
 ## [3.3.1] - 2026-05-29
 

--- a/buildpacks/static-web-server/CHANGELOG.md
+++ b/buildpacks/static-web-server/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report the `cnb.static-web-server.config.caddy_server_opts_clean_urls` metric with its actual boolean value, so disabled clean URLs emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.caddy_server_opts_access_logs` metric with its actual boolean value, so disabled access logs emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.response_headers_enabled` metric on every build, emitting `false` when no response headers are configured instead of being omitted.
+- Report the `cnb.static-web-server.config.caddy_server_opts_static_responses` metric on every build, emitting `false` when no static responses are configured instead of being omitted.
 
 ## [3.3.1] - 2026-05-29
 

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -219,15 +219,15 @@ fn generate_static_response_handlers(
     config: &HerokuWebServerConfig,
     static_file_handlers: &mut Vec<serde_json::Value>,
 ) -> Result<(), StaticWebServerBuildpackError> {
-    if let Some(static_responses) = config
+    let static_responses_opt = config
         .caddy_server_opts
         .as_ref()
-        .and_then(|v| v.static_responses.clone())
-    {
-        tracing::info!(
-            { CONFIG_CADDY_SERVER_OPTS_STATIC_RESPONSES } = true,
-            "config"
-        );
+        .and_then(|v| v.static_responses.clone());
+    tracing::info!(
+        { CONFIG_CADDY_SERVER_OPTS_STATIC_RESPONSES } = static_responses_opt.is_some(),
+        "config"
+    );
+    if let Some(static_responses) = static_responses_opt {
         for static_response in static_responses {
             // Validate that at least one matcher is set
             if static_response.host_matcher.is_none() && static_response.path_matcher.is_none() {

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -36,12 +36,15 @@ pub(crate) fn caddy_json_config(
 
     let mut static_file_handlers = vec![];
 
-    if config
+    let basic_auth_enabled = config
         .caddy_server_opts
         .as_ref()
-        .is_some_and(|v| v.basic_auth.is_some_and(|vv| vv))
-    {
-        tracing::info!({ CONFIG_CADDY_SERVER_OPTS_BASIC_AUTH } = true, "config");
+        .is_some_and(|v| v.basic_auth.is_some_and(|vv| vv));
+    tracing::info!(
+        { CONFIG_CADDY_SERVER_OPTS_BASIC_AUTH } = basic_auth_enabled,
+        "config"
+    );
+    if basic_auth_enabled {
         static_file_handlers.push(json!(
         {
             "handler": "subroute",

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -83,12 +83,15 @@ pub(crate) fn caddy_json_config(
 
     generate_static_response_handlers(config, &mut static_file_handlers)?;
 
-    if config
+    let templates_enabled = config
         .caddy_server_opts
         .as_ref()
-        .is_some_and(|v| v.templates.is_some_and(|vv| vv))
-    {
-        tracing::info!({ CONFIG_CADDY_SERVER_OPTS_TEMPLATES } = true, "config");
+        .is_some_and(|v| v.templates.is_some_and(|vv| vv));
+    tracing::info!(
+        { CONFIG_CADDY_SERVER_OPTS_TEMPLATES } = templates_enabled,
+        "config"
+    );
+    if templates_enabled {
         static_file_handlers.push(json!(
         {
             "handler": "templates",

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -17,8 +17,11 @@ pub(crate) fn caddy_json_config(
     let mut routes = vec![];
 
     // Header routes come first so headers will be added to any response down the chain.
+    tracing::info!(
+        { CONFIG_RESPONSE_HEADERS_ENABLED } = config.headers.is_some(),
+        "config"
+    );
     if let Some(ref headers) = config.headers {
-        tracing::info!({ CONFIG_RESPONSE_HEADERS_ENABLED } = true, "config");
         routes.extend(generate_response_headers_routes(headers));
     }
 

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -152,8 +152,13 @@ pub(crate) fn caddy_json_config(
         .caddy_server_opts
         .as_ref()
         .and_then(|v| v.access_logs.as_ref());
-    if caddy_access_logs_config.is_some_and(|vv| vv.enabled.is_some_and(|vvv| vvv)) {
-        tracing::info!({ CONFIG_CADDY_SERVER_OPTS_ACCESS_LOGS } = true, "config");
+    let access_logs_enabled =
+        caddy_access_logs_config.is_some_and(|vv| vv.enabled.is_some_and(|vvv| vvv));
+    tracing::info!(
+        { CONFIG_CADDY_SERVER_OPTS_ACCESS_LOGS } = access_logs_enabled,
+        "config"
+    );
+    if access_logs_enabled {
         server_logs_config = json!({
             "default_logger_name": "public"
         });

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -98,12 +98,15 @@ pub(crate) fn caddy_json_config(
         }));
     }
 
-    if config
+    let clean_urls_enabled = config
         .caddy_server_opts
         .as_ref()
-        .is_some_and(|v| v.clean_urls.is_some_and(|vv| vv))
-    {
-        tracing::info!({ CONFIG_CADDY_SERVER_OPTS_CLEAN_URLS } = true, "config");
+        .is_some_and(|v| v.clean_urls.is_some_and(|vv| vv));
+    tracing::info!(
+        { CONFIG_CADDY_SERVER_OPTS_CLEAN_URLS } = clean_urls_enabled,
+        "config"
+    );
+    if clean_urls_enabled {
         static_file_handlers.push(json!(
         {
             "handler": "subroute",

--- a/buildpacks/static-web-server/src/config_web_server.rs
+++ b/buildpacks/static-web-server/src/config_web_server.rs
@@ -86,12 +86,13 @@ pub(crate) fn config_web_server(
         enabled: None,
         html_files: None,
     });
-    if runtime_config.enabled.unwrap_or(true) {
+    let runtime_config_enabled = runtime_config.enabled.unwrap_or(true);
+    tracing::info!(
+        { CONFIG_RUNTIME_CONFIG_ENABLED } = runtime_config_enabled,
+        "runtime configuration"
+    );
+    if runtime_config_enabled {
         log_info("Installing runtime configuration process…");
-        tracing::info!(
-            { CONFIG_RUNTIME_CONFIG_ENABLED } = true,
-            "runtime configuration"
-        );
         let web_exec_destination = configuration_layer.path().join("exec.d/web");
         let exec_path = web_exec_destination.join("env-as-html-data");
         log_info(format!("  {}", exec_path.display()));


### PR DESCRIPTION
## What

Seven boolean/toggle observability metrics in the static-web-server buildpack were emitted only inside their "enabled" branch with a hardcoded `= true`. When the feature was disabled (or not configured), no metric was emitted at all — so downstream `false` was indistinguishable from "build never reached that code." This makes each metric report its real boolean value on every build.

Each fix is its own commit:

- `runtime_config_enabled` — reports `enabled.unwrap_or(true)`
- `caddy_server_opts_basic_auth` — reports real bool
- `caddy_server_opts_templates` — reports real bool
- `caddy_server_opts_clean_urls` — reports real bool
- `caddy_server_opts_access_logs` — reports real bool
- `response_headers_enabled` — reports `config.headers.is_some()`
- `caddy_server_opts_static_responses` — reports `static_responses.is_some()`

The first five are backed by user-settable `Option<bool>` fields (a user can explicitly set `false`); the last two are presence-driven, where "absent" is the natural negative.

## How

For each metric, the `tracing::info!` emit was hoisted above its conditional and the literal `true` replaced with the actual boolean. The Caddy JSON output and config logic are unchanged — this is a tracing-only change.

## ⚠️ Downstream impact

Emitting explicit `false` changes metric volume. Any dashboard or query that currently treats "metric present" as "enabled = true" will start seeing `false` rows and should be updated to filter on the value.

## Testing

- `cargo build -p static-web-server` — clean
- `cargo clippy -p static-web-server` — clean
- `cargo test -p static-web-server --bins` — 27 passed, 0 failed

No tests assert on metric emissions, so behavior is preserved.