### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-# Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
-#GUSINFO:Open Source,Open Source Workflow
+#GUSINFO:Heroku FE Infra & Arch,Heroku Front-End Infra
+* @heroku/front-end-infra @heroku/languages


### PR DESCRIPTION
The CODEOWNERS file had the unedited oss-template placeholder. Assign ownership to both @heroku/front-end-infra and @heroku/languages, reflecting the collaborative ownership of this CNB. Listing both teams on one rule means GitHub requests a review from either team (owners on a line are OR'd).

See also:
https://salesforce-internal.slack.com/archives/C01R6FJ738U/p1782757487187129

GUS-W-23211370.