### PR TITLE
Add test_support to the workspace members list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ members = [
     "buildpacks/website-vite",
     "buildpacks/static-web-server",
     "common/env_as_html_data",
-    "common/static_web_server_utils"
+    "common/static_web_server_utils",
+    "test_support"
 ]
 
 [workspace.package]


### PR DESCRIPTION
`test_support` is currently only an implicit workspace member (via the path dependency other crates declare on it). Dependabot rewrites dependency versions only in explicitly-listed members, so on a bump PR it updates every crate except `test_support`, leaving it pinned to the old version and producing an unsatisfiable version conflict that fails CI — e.g. the libcnb group bump in #117.

Listing it explicitly fixes that, and matches how the other crates are declared.

GUS-W-23329202.