### PR TITLE
Fix `useless_borrows_in_formatting` clippy lint

### DIFF
--- a/common/env_as_html_data/src/lib.rs
+++ b/common/env_as_html_data/src/lib.rs
@@ -169,7 +169,7 @@ fn inject_html_data_attrs<S: BuildHasher>(
         ..
     } = &element.data
     else {
-        return Err(Error::ElementExpected(format!("{:?}", &element.data)));
+        return Err(Error::ElementExpected(format!("{:?}", element.data)));
     };
 
     let keys = runtime_env_keys(data);


### PR DESCRIPTION
Remove a redundant `&` in a `format!` argument in `env_as_html_data`. CI uses stable clippy, which doesn't flag this yet, so it was latent on `main` — but the next Rust version (currently in beta) promotes it to a lint, at which point CI would start failing.

GUS-W-23336502.