### PR TITLE
Add env-matched response headers (`headers_for_env`)

### DIFF
--- a/buildpacks/static-web-server/CHANGELOG.md
+++ b/buildpacks/static-web-server/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add env-matched response headers configuration, `[com.heroku.static-web-server.headers_for_env]`, applying custom response headers only when the runtime `WEB_ENV` env var matches. Report the new `cnb.static-web-server.config.env_matched_headers_enabled` metric on every build.
+
 ## [3.3.2] - 2026-06-30
 
 - Report the `cnb.static-web-server.config.runtime_config_enabled` metric with its actual boolean value, so a disabled runtime config emits `false` instead of being omitted.

--- a/buildpacks/static-web-server/CHANGELOG.md
+++ b/buildpacks/static-web-server/CHANGELOG.md
@@ -5,11 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Types of changes:
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Deprecated` for soon-to-be removed features.
+- `Removed` for now removed features.
+- `Fixed` for any bug fixes.
+- `Security` in case of vulnerabilities.
+
 ## [Unreleased]
+
+### Added
 
 - Add env-matched response headers configuration, `[com.heroku.static-web-server.headers_for_env]`, applying custom response headers only when the runtime `WEB_ENV` env var matches. Report the new `cnb.static-web-server.config.env_matched_headers_enabled` metric on every build.
 
 ## [3.3.2] - 2026-06-30
+
+### Fixed
 
 - Report the `cnb.static-web-server.config.runtime_config_enabled` metric with its actual boolean value, so a disabled runtime config emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.caddy_server_opts_basic_auth` metric with its actual boolean value, so disabled basic auth emits `false` instead of being omitted.
@@ -18,9 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report the `cnb.static-web-server.config.caddy_server_opts_access_logs` metric with its actual boolean value, so disabled access logs emits `false` instead of being omitted.
 - Report the `cnb.static-web-server.config.response_headers_enabled` metric on every build, emitting `false` when no response headers are configured instead of being omitted.
 - Report the `cnb.static-web-server.config.caddy_server_opts_static_responses` metric on every build, emitting `false` when no static responses are configured instead of being omitted.
+
+### Changed
+
 - Update Caddy web server version to 2.11.4.
 
 ## [3.3.1] - 2026-05-29
+
+### Changed
 
 - Update Caddy web server version to 2.11.3.
 

--- a/buildpacks/static-web-server/README.md
+++ b/buildpacks/static-web-server/README.md
@@ -255,6 +255,20 @@ Cache-Control = "public, max-age=604800"
 Content-Disposition = "attachment"
 ```
 
+#### Env-matched Headers
+
+Respond with custom [global](#global-headers) and [path-matched](#path-matched-headers) headers, when the `WEB_ENV` env var matches a term at runtime.
+
+```toml
+# Any request `*` when the server's WEB_ENV == staging
+[com.heroku.static-web-server.headers_for_env."staging"."*"]
+Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
+
+# Any request `*` when the server's WEB_ENV == production
+[com.heroku.static-web-server.headers_for_env."production"."*"]
+Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.example.com;"
+```
+
 ### Custom Errors
 
 *Default: (server's built-in errors)*
@@ -601,11 +615,13 @@ docker run \
 
 The static web server is configured to handle request URLs with the following path-matched precedence:
 
-1. [optional] [Caddy: Basic Authorization](#caddy-basic-authorization)
-2. [optional] [Caddy: Static Responses](#caddy-static-responses) (terminating)
-3. [optional] [Caddy: Clean URLs](#caddy-clean-urls)
+1. [optional] [Response Headers](#response-headers)
+2. [optional] [Caddy: Basic Authorization](#caddy-basic-authorization)
+3. [optional] [Caddy: Static Responses](#caddy-static-responses) (terminating)
+4. [optional] [Caddy: Clean URLs](#caddy-clean-urls)
     1. exact URL path
     2. URL path + `.html` (rewrite)
-4. File Server
+5. File Server
     1. exact URL path
     2. for directories, URL path + default document `index.html`
+6. [Not Found handler](#404-not-found)

--- a/buildpacks/static-web-server/README.md
+++ b/buildpacks/static-web-server/README.md
@@ -223,7 +223,7 @@ index = "main.html"
 
 #### Global Headers
 
-Respond with custom headers for any request path, the wildcard `*`.
+`headers."*"` applies headers for every request, unless overriden by a subsequent or more specific header path or env.
 
 ```toml
 [com.heroku.static-web-server.headers."*"]
@@ -232,9 +232,11 @@ X-Server = "hot stuff"
 
 #### Path-matched Headers
 
-Respond with custom headers. These match exactly against the request URL's path.
+*Default: (the configured global headers)*
 
-Wildcards `*` are supported as implemented. (See [Caddy "path" matcher](https://caddyserver.com/docs/json//apps/http/servers/routes/match/path) for syntax details.)
+`headers.PATH` selectively applies headers for `PATH`. These match exactly against the request URL's path.
+
+Wildcards in the path `*` are supported. (Server-specific implementation, see [Caddy "path" matcher](https://caddyserver.com/docs/json//apps/http/servers/routes/match/path) for syntax details.)
 
 ```toml
 # The index page (index.html is not specified in the URL).
@@ -257,15 +259,26 @@ Content-Disposition = "attachment"
 
 #### Env-matched Headers
 
-Respond with custom [global](#global-headers) and [path-matched](#path-matched-headers) headers, when the `WEB_ENV` env var matches a term at runtime.
+*Default: (the configured global and path-matched headers)*
+
+`headers_for_env.NAME.PATH` selectively applies headers for `PATH` by matching `NAME` to the value of `WEB_ENV` environment variable. 
+
+Supports custom [global](#global-headers) and [path-matched](#path-matched-headers) headers, scoped to the `WEB_ENV`.
 
 ```toml
-# Any request `*` when the server's WEB_ENV == staging
-[com.heroku.static-web-server.headers_for_env."staging"."*"]
-Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
+[com.heroku.static-web-server.headers_for_env.production."*"]
+Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.example.com;"
+```
 
-# Any request `*` when the server's WEB_ENV == production
-[com.heroku.static-web-server.headers_for_env."production"."*"]
+For example, set default and production-specific CSP headers,
+
+```toml
+# Globally set headers
+[com.heroku.static-web-server.headers."*"]
+Content-Security-Policy = "default-src https: 'self'; connect-src 'self' *.example.com;"
+
+# and then override the default, when the server's WEB_ENV == "production"
+[com.heroku.static-web-server.headers_for_env.production."*"]
 Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.example.com;"
 ```
 

--- a/buildpacks/static-web-server/src/caddy_config.rs
+++ b/buildpacks/static-web-server/src/caddy_config.rs
@@ -1,5 +1,6 @@
 use crate::heroku_web_server_config::{
-    ErrorsConfig, HerokuWebServerConfig, PathMatchedHeader, DEFAULT_DOC_INDEX, DEFAULT_DOC_ROOT,
+    EnvMatchedHeader, ErrorsConfig, HerokuWebServerConfig, PathMatchedHeader, DEFAULT_DOC_INDEX,
+    DEFAULT_DOC_ROOT,
 };
 use crate::o11y::*;
 use crate::StaticWebServerBuildpackError;
@@ -23,6 +24,17 @@ pub(crate) fn caddy_json_config(
     );
     if let Some(ref headers) = config.headers {
         routes.extend(generate_response_headers_routes(headers));
+    }
+
+    // Env-matched header routes come after the build-time header routes, so that when both
+    // set the same header key for a matching request, the env-matched value wins (Caddy runs
+    // the non-terminal `headers` handlers in route order, and the later `set` takes effect).
+    tracing::info!(
+        { CONFIG_ENV_MATCHED_HEADERS_ENABLED } = config.headers_for_env.is_some(),
+        "config"
+    );
+    if let Some(ref headers_for_env) = config.headers_for_env {
+        routes.extend(generate_env_matched_headers_routes(headers_for_env));
     }
 
     let doc_root = config
@@ -316,6 +328,54 @@ fn generate_response_headers_routes(headers: &Vec<PathMatchedHeader>) -> Vec<ser
         .collect()
 }
 
+fn generate_env_matched_headers_routes(headers: &Vec<EnvMatchedHeader>) -> Vec<serde_json::Value> {
+    // Group headers sharing the same (env term, path matcher) while preserving the order of
+    // the groups by "when-first-seen".
+    let mut groups = IndexMap::<(String, String), Vec<&EnvMatchedHeader>>::new();
+    for header in headers {
+        let key = (header.env_matcher.clone(), header.path_matcher.clone());
+        if let Some(existing) = groups.get_mut(&key) {
+            existing.push(header);
+        } else {
+            groups.insert(key, vec![header]);
+        }
+    }
+
+    groups
+        .into_iter()
+        .map(|((env_matcher, path_matcher), headers)| {
+            let headers_as_hash_map = headers
+                .into_iter()
+                .map(|header| (header.key.clone(), vec![header.value.clone()]))
+                .collect::<HashMap<_, _>>();
+
+            // The `path` and `WEB_ENV` `expression` matchers share one match-set object, so
+            // Caddy requires BOTH to match (matchers within a single object are ANDed).
+            // `{env.WEB_ENV}` is resolved by Caddy at runtime, matching the basic-auth precedent.
+            json!({
+                "match": [{
+                    "path": vec![path_matcher],
+                    "expression": {
+                        "expr": format!("{{env.WEB_ENV}} == '{}'", cel_escape(&env_matcher)),
+                        "name": format!("web_env_{env_matcher}")
+                    }
+                }],
+                "handle": [{
+                    "handler": "headers",
+                    "response": {
+                        "set": headers_as_hash_map
+                    }
+                }]
+            })
+        })
+        .collect()
+}
+
+/// Escapes a value for safe interpolation into a single-quoted CEL string literal.
+fn cel_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
 fn generate_error_404_route(
     doc_root: &str,
     doc_index: &str,
@@ -468,6 +528,74 @@ mod tests {
             routes,
             vec![
                 json!({"handle": [{"handler":"headers","response":{"set":{"X-Foo":["Bar"]}}}],"match":[{"path":["*"]}]})
+            ]
+        );
+    }
+
+    #[test]
+    fn generates_env_matched_headers_routes() {
+        let headers = vec![
+            EnvMatchedHeader {
+                env_matcher: String::from("staging"),
+                path_matcher: String::from("*"),
+                key: String::from("Content-Security-Policy"),
+                value: String::from(
+                    "default-src https: 'self'; connect-src 'self' api.staging.example.com;",
+                ),
+            },
+            EnvMatchedHeader {
+                env_matcher: String::from("production"),
+                path_matcher: String::from("*"),
+                key: String::from("Content-Security-Policy"),
+                value: String::from(
+                    "default-src https: 'self'; connect-src 'self' api.example.com;",
+                ),
+            },
+        ];
+
+        let routes = generate_env_matched_headers_routes(&headers);
+
+        assert_eq!(
+            routes,
+            vec![
+                json!({"handle":[{"handler":"headers","response":{"set":{"Content-Security-Policy":["default-src https: 'self'; connect-src 'self' api.staging.example.com;"]}}}],"match":[{"path":["*"],"expression":{"expr":"{env.WEB_ENV} == 'staging'","name":"web_env_staging"}}]}),
+                json!({"handle":[{"handler":"headers","response":{"set":{"Content-Security-Policy":["default-src https: 'self'; connect-src 'self' api.example.com;"]}}}],"match":[{"path":["*"],"expression":{"expr":"{env.WEB_ENV} == 'production'","name":"web_env_production"}}]})
+            ]
+        );
+    }
+
+    #[test]
+    fn groups_env_matched_headers_by_env_and_path() {
+        let headers = vec![
+            EnvMatchedHeader {
+                env_matcher: String::from("staging"),
+                path_matcher: String::from("*"),
+                key: String::from("X-Foo"),
+                value: String::from("Bar"),
+            },
+            EnvMatchedHeader {
+                env_matcher: String::from("staging"),
+                path_matcher: String::from("/admin/*"),
+                key: String::from("X-Robots-Tag"),
+                value: String::from("noindex"),
+            },
+            EnvMatchedHeader {
+                env_matcher: String::from("staging"),
+                path_matcher: String::from("*"),
+                key: String::from("X-Zuu"),
+                value: String::from("Zem"),
+            },
+        ];
+
+        let routes = generate_env_matched_headers_routes(&headers);
+
+        // Same env + path collapse into one route with both keys; the different path is its
+        // own route.
+        assert_eq!(
+            routes,
+            vec![
+                json!({"handle":[{"handler":"headers","response":{"set":{"X-Foo":["Bar"],"X-Zuu":["Zem"]}}}],"match":[{"path":["*"],"expression":{"expr":"{env.WEB_ENV} == 'staging'","name":"web_env_staging"}}]}),
+                json!({"handle":[{"handler":"headers","response":{"set":{"X-Robots-Tag":["noindex"]}}}],"match":[{"path":["/admin/*"],"expression":{"expr":"{env.WEB_ENV} == 'staging'","name":"web_env_staging"}}]})
             ]
         );
     }

--- a/buildpacks/static-web-server/src/heroku_web_server_config.rs
+++ b/buildpacks/static-web-server/src/heroku_web_server_config.rs
@@ -15,6 +15,8 @@ pub(crate) struct HerokuWebServerConfig {
     pub(crate) errors: Option<ErrorsConfig>,
     #[serde(default, deserialize_with = "deserialize_path_matched_headers")]
     pub(crate) headers: Option<Vec<PathMatchedHeader>>,
+    #[serde(default, deserialize_with = "deserialize_env_matched_headers")]
+    pub(crate) headers_for_env: Option<Vec<EnvMatchedHeader>>,
     pub(crate) runtime_config: Option<RuntimeConfig>,
     pub(crate) caddy_server_opts: Option<CaddyServerOpts>,
 }
@@ -40,6 +42,14 @@ pub(crate) struct Executable {
 
 #[derive(Deserialize, Eq, PartialEq, Debug, Default, Clone)]
 pub(crate) struct PathMatchedHeader {
+    pub(crate) path_matcher: String,
+    pub(crate) key: String,
+    pub(crate) value: String,
+}
+
+#[derive(Deserialize, Eq, PartialEq, Debug, Default, Clone)]
+pub(crate) struct EnvMatchedHeader {
+    pub(crate) env_matcher: String,
     pub(crate) path_matcher: String,
     pub(crate) key: String,
     pub(crate) value: String,
@@ -158,6 +168,52 @@ impl<'de> Visitor<'de> for PathMatchedHeadersVisitor {
                     key: header_key,
                     value: header_value,
                 });
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+fn deserialize_env_matched_headers<'de, D>(d: D) -> Result<Option<Vec<EnvMatchedHeader>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let deserialized = d.deserialize_map(EnvMatchedHeadersVisitor)?;
+
+    if deserialized.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(deserialized))
+    }
+}
+
+struct EnvMatchedHeadersVisitor;
+
+impl<'de> Visitor<'de> for EnvMatchedHeadersVisitor {
+    type Value = Vec<EnvMatchedHeader>;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        write!(formatter, "an env-matched, path-matched HTTP header map")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut result = vec![];
+        while let Some((env_matcher, path_map)) =
+            map.next_entry::<String, BTreeMap<String, BTreeMap<String, String>>>()?
+        {
+            for (path_matcher, headers) in path_map {
+                for (header_key, header_value) in headers {
+                    result.push(EnvMatchedHeader {
+                        env_matcher: env_matcher.clone(),
+                        path_matcher: path_matcher.clone(),
+                        key: header_key,
+                        value: header_value,
+                    });
+                }
             }
         }
 
@@ -468,6 +524,49 @@ mod tests {
                     path_matcher: String::from("/images/*"),
                     key: String::from("X-Only-Images"),
                     value: String::from("HAI")
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn custom_headers_for_env() {
+        let toml_config = toml! {
+            [headers_for_env]
+            "staging"."*".Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
+            "staging"."/admin/*".X-Robots-Tag = "noindex"
+            "production"."*".Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.example.com;"
+        };
+
+        let parsed_config = toml_config.try_into::<HerokuWebServerConfig>().unwrap();
+        assert_eq!(parsed_config.headers, None);
+
+        // Outer env terms preserve TOML document order (staging, then production).
+        // Inner path matchers are BTreeMap-sorted ("*" sorts before "/admin/*").
+        assert_eq!(
+            parsed_config.headers_for_env,
+            Some(vec![
+                EnvMatchedHeader {
+                    env_matcher: String::from("staging"),
+                    path_matcher: String::from("*"),
+                    key: String::from("Content-Security-Policy"),
+                    value: String::from(
+                        "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
+                    )
+                },
+                EnvMatchedHeader {
+                    env_matcher: String::from("staging"),
+                    path_matcher: String::from("/admin/*"),
+                    key: String::from("X-Robots-Tag"),
+                    value: String::from("noindex")
+                },
+                EnvMatchedHeader {
+                    env_matcher: String::from("production"),
+                    path_matcher: String::from("*"),
+                    key: String::from("Content-Security-Policy"),
+                    value: String::from(
+                        "default-src https: 'self'; connect-src 'self' api.example.com;"
+                    )
                 },
             ])
         );

--- a/buildpacks/static-web-server/src/o11y.rs
+++ b/buildpacks/static-web-server/src/o11y.rs
@@ -31,6 +31,8 @@ pub(crate) const CONFIG_ERROR_404_FILE_PATH: &str = formatcp!("{CONFIG}.error_40
 pub(crate) const CONFIG_ERROR_404_STATUS_CODE: &str = formatcp!("{CONFIG}.error_404_status_code");
 pub(crate) const CONFIG_RESPONSE_HEADERS_ENABLED: &str =
     formatcp!("{CONFIG}.response_headers_enabled");
+pub(crate) const CONFIG_ENV_MATCHED_HEADERS_ENABLED: &str =
+    formatcp!("{CONFIG}.env_matched_headers_enabled");
 
 const ERROR: &str = formatcp!("{NAMESPACE}.error");
 pub(crate) const ERROR_ID: &str = formatcp!("{ERROR}.id");

--- a/buildpacks/static-web-server/tests/fixtures/custom_headers/project.toml
+++ b/buildpacks/static-web-server/tests/fixtures/custom_headers/project.toml
@@ -3,3 +3,9 @@
 "/".X-Only-Default = "Hiii"
 "*.html".X-Only-HTML = "Hi"
 "/images/*".X-Only-Images = "HAI"
+
+[com.heroku.static-web-server.headers_for_env]
+"staging"."*".Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
+# Overrides the build-time `headers."*".X-Global` value above, to verify env-matched wins.
+"staging"."*".X-Global = "Hello-Staging"
+"production"."*".Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.example.com;"

--- a/buildpacks/static-web-server/tests/fixtures/custom_headers/project.toml
+++ b/buildpacks/static-web-server/tests/fixtures/custom_headers/project.toml
@@ -4,8 +4,10 @@
 "*.html".X-Only-HTML = "Hi"
 "/images/*".X-Only-Images = "HAI"
 
-[com.heroku.static-web-server.headers_for_env]
-"staging"."*".Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
+[com.heroku.static-web-server.headers_for_env.staging."*"]
+Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
 # Overrides the build-time `headers."*".X-Global` value above, to verify env-matched wins.
-"staging"."*".X-Global = "Hello-Staging"
-"production"."*".Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.example.com;"
+X-Global = "Hello-Staging"
+
+[com.heroku.static-web-server.headers_for_env.production."*"]
+Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.example.com;"

--- a/buildpacks/static-web-server/tests/fixtures/custom_headers/project.toml
+++ b/buildpacks/static-web-server/tests/fixtures/custom_headers/project.toml
@@ -1,13 +1,15 @@
 [com.heroku.static-web-server.headers]
 "*".X-Global = "Hello"
+"*".Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
 "/".X-Only-Default = "Hiii"
 "*.html".X-Only-HTML = "Hi"
 "/images/*".X-Only-Images = "HAI"
 
 [com.heroku.static-web-server.headers_for_env.staging."*"]
-Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
-# Overrides the build-time `headers."*".X-Global` value above, to verify env-matched wins.
 X-Global = "Hello-Staging"
 
 [com.heroku.static-web-server.headers_for_env.production."*"]
 Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.example.com;"
+
+[com.heroku.static-web-server.headers_for_env.production."/page2.html"]
+X-Global = "Hello-in-prod-page-2"

--- a/buildpacks/static-web-server/tests/integration_test.rs
+++ b/buildpacks/static-web-server/tests/integration_test.rs
@@ -160,6 +160,7 @@ fn top_level_doc_root() {
 
 #[test]
 #[ignore = "integration test"]
+#[allow(clippy::too_many_lines)]
 fn custom_headers() {
     static_web_server_integration_test("./fixtures/custom_headers", |ctx| {
         assert_contains!(ctx.pack_stdout, "Static Web Server");
@@ -189,6 +190,11 @@ fn custom_headers() {
                     !response.headers().contains_key("X-Only-HTML"),
                     "should not include X-Only-HTML header"
                 );
+                // Without WEB_ENV set, no `headers_for_env` headers apply.
+                assert!(
+                    !response.headers().contains_key("Content-Security-Policy"),
+                    "should not include Content-Security-Policy header when WEB_ENV is unset"
+                );
 
                 let response = retry(DEFAULT_RETRIES, DEFAULT_RETRY_DELAY, || {
                     ureq::get(&format!("http://{socket_addr}/page2.html"))
@@ -206,6 +212,64 @@ fn custom_headers() {
                     !response.headers().contains_key("X-Only-Default"),
                     "should not include X-Only-Default header"
                 );
+            },
+        );
+
+        // WEB_ENV=staging applies the staging `headers_for_env` headers.
+        start_container(
+            &ctx,
+            ContainerConfig::new().env("WEB_ENV", "staging"),
+            |_container, socket_addr| {
+                let response = retry(DEFAULT_RETRIES, DEFAULT_RETRY_DELAY, || {
+                    ureq::get(&format!("http://{socket_addr}/"))
+                        .call()
+                        .map_err(Box::new)
+                })
+                .unwrap();
+                let h = response
+                    .headers()
+                    .get("Content-Security-Policy")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                assert_contains!(h, "api.staging.example.com");
+                // Env-matched headers override the build-time `headers` value for the same key.
+                let h = response
+                    .headers()
+                    .get("X-Global")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                assert_contains!(h, "Hello-Staging");
+            },
+        );
+
+        // WEB_ENV=production applies the production `headers_for_env` headers.
+        start_container(
+            &ctx,
+            ContainerConfig::new().env("WEB_ENV", "production"),
+            |_container, socket_addr| {
+                let response = retry(DEFAULT_RETRIES, DEFAULT_RETRY_DELAY, || {
+                    ureq::get(&format!("http://{socket_addr}/"))
+                        .call()
+                        .map_err(Box::new)
+                })
+                .unwrap();
+                let h = response
+                    .headers()
+                    .get("Content-Security-Policy")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                assert_contains!(h, "api.example.com");
+                assert!(
+                    !h.contains("staging"),
+                    "production Content-Security-Policy must not contain the staging host"
+                );
+                // The production env does not override X-Global, so the build-time value stands.
+                let h = response
+                    .headers()
+                    .get("X-Global")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                assert_contains!(h, "Hello");
             },
         );
     });

--- a/buildpacks/static-web-server/tests/integration_test.rs
+++ b/buildpacks/static-web-server/tests/integration_test.rs
@@ -182,6 +182,15 @@ fn custom_headers() {
                 assert_contains!(h, "Hello");
                 let h = response
                     .headers()
+                    .get("Content-Security-Policy")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                assert_contains!(
+                    h,
+                    "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
+                );
+                let h = response
+                    .headers()
                     .get("X-Only-Default")
                     .and_then(|v| v.to_str().ok())
                     .unwrap_or_default();
@@ -190,11 +199,6 @@ fn custom_headers() {
                     !response.headers().contains_key("X-Only-HTML"),
                     "should not include X-Only-HTML header"
                 );
-                // Without WEB_ENV set, no `headers_for_env` headers apply.
-                assert!(
-                    !response.headers().contains_key("Content-Security-Policy"),
-                    "should not include Content-Security-Policy header when WEB_ENV is unset"
-                );
 
                 let response = retry(DEFAULT_RETRIES, DEFAULT_RETRY_DELAY, || {
                     ureq::get(&format!("http://{socket_addr}/page2.html"))
@@ -202,6 +206,21 @@ fn custom_headers() {
                         .map_err(Box::new)
                 })
                 .unwrap();
+                let h = response
+                    .headers()
+                    .get("X-Global")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                assert_contains!(h, "Hello");
+                let h = response
+                    .headers()
+                    .get("Content-Security-Policy")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                assert_contains!(
+                    h,
+                    "default-src https: 'self'; connect-src 'self' api.staging.example.com;"
+                );
                 let h = response
                     .headers()
                     .get("X-Only-HTML")
@@ -270,6 +289,38 @@ fn custom_headers() {
                     .and_then(|v| v.to_str().ok())
                     .unwrap_or_default();
                 assert_contains!(h, "Hello");
+
+                let response = retry(DEFAULT_RETRIES, DEFAULT_RETRY_DELAY, || {
+                    ureq::get(&format!("http://{socket_addr}/page2.html"))
+                        .call()
+                        .map_err(Box::new)
+                })
+                .unwrap();
+                let h = response
+                    .headers()
+                    .get("X-Global")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                assert_contains!(h, "Hello-in-prod-page-2");
+                let h = response
+                    .headers()
+                    .get("Content-Security-Policy")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                assert_contains!(
+                    h,
+                    "default-src https: 'self'; connect-src 'self' api.example.com;"
+                );
+                let h = response
+                    .headers()
+                    .get("X-Only-HTML")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                assert_contains!(h, "Hi");
+                assert!(
+                    !response.headers().contains_key("X-Only-Default"),
+                    "should not include X-Only-Default header"
+                );
             },
         );
     });


### PR DESCRIPTION
## What

Adds a new flavor of Response Header configuration: **Env-matched Headers**, documented in the static-web-server README's "Env-matched Headers" section.

New `project.toml` config applies custom response headers only when the runtime `WEB_ENV` env var matches a term:

```toml
# Globally set headers
[com.heroku.static-web-server.headers."*"]
Content-Security-Policy = "default-src https: 'self'; connect-src 'self' *.example.com;"

# and then override the default, when the server's WEB_ENV == "production"
[com.heroku.static-web-server.headers_for_env.production."*"]
Content-Security-Policy = "default-src https: 'self'; connect-src 'self' api.example.com;"
```

This lets a single built image serve environment-specific headers (e.g. a staging vs. production CSP) without a rebuild — promote the image and just change `WEB_ENV`.

## How

`WEB_ENV` is only known at launch, so this can't be resolved at build time. Instead, each generated Caddy route combines its `path` matcher with an `{env.WEB_ENV} == '<term>'` CEL `expression` matcher in the **same** match-set object (Caddy ANDs matchers within one object). This mirrors the existing runtime-env pattern already shipping for Basic Auth's `WEB_BASIC_AUTH_DISABLED` gate.

Mirrors the existing `headers` feature end-to-end:
- New `EnvMatchedHeader` struct + `headers_for_env` field + `deserialize_env_matched_headers` visitor (flattens the 3-level nested `env → path matcher → header map`) in `heroku_web_server_config.rs`.
- New `generate_env_matched_headers_routes` (+ `cel_escape` helper) in `caddy_config.rs`.
- New `CONFIG_ENV_MATCHED_HEADERS_ENABLED` o11y metric, reported on every build.

**Override precedence:** env-matched routes are emitted *after* the build-time `headers` routes, so when both set the same header key for a matching request the env-matched value wins (Caddy runs non-terminal `headers` handlers in route order; the later `set` takes effect).

## Testing

- New unit tests: deserialization (`custom_headers_for_env`), Caddy-gen (`generates_env_matched_headers_routes`, `groups_env_matched_headers_by_env_and_path`).
- Extended the existing `custom_headers` integration test + fixture with `staging` / `production` / unset-`WEB_ENV` cases, including an override of a build-time header key to lock precedence.
- `cargo test --bins`, `cargo clippy --all-targets`, `cargo fmt --check`: all clean.
- Verified live against a running Caddy instance (all three `WEB_ENV` cases behave as expected, including the override).
- The containerized integration test (`cargo test -p static-web-server --test integration_test -- --ignored --test-threads 16`) passed.