### PR TITLE
JavaScript module `env-as-html-data` to support local development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,8 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
-    open-pull-requests-limit: 5
     schedule:
-      interval: "weekly"
-      time: "12:00"
-      day: "sunday"
-      timezone: "America/Los_Angeles"
+      interval: "monthly"
     groups:
       libcnb:
         patterns:
@@ -33,12 +29,8 @@ updates:
           - "markup5ever_rcdom"
   - package-ecosystem: "github-actions"
     directory: "/"
-    open-pull-requests-limit: 5
     schedule:
-      interval: "weekly"
-      time: "12:00"
-      day: "sunday"
-      timezone: "America/Los_Angeles"
+      interval: "monthly"
     groups:
       github-actions:
         update-types:
@@ -46,9 +38,13 @@ updates:
           - "patch"
   - package-ecosystem: "npm"
     directory: "/"
-    open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
       time: "12:00"
       day: "sunday"
       timezone: "America/Los_Angeles"
+    groups:
+      javascript-dependencies:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,12 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    open-pull-requests-limit: 5
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      time: "12:00"
+      day: "sunday"
+      timezone: "America/Los_Angeles"
     groups:
       libcnb:
         patterns:
@@ -29,10 +33,22 @@ updates:
           - "markup5ever_rcdom"
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 5
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      time: "12:00"
+      day: "sunday"
+      timezone: "America/Los_Angeles"
     groups:
       github-actions:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "npm"
+    directory: "/"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+      time: "12:00"
+      day: "sunday"
+      timezone: "America/Los_Angeles"

--- a/buildpacks/static-web-server/README.md
+++ b/buildpacks/static-web-server/README.md
@@ -98,6 +98,12 @@ const response = await fetch(document.head.dataset.public_web_api_url, {
 });
 ```
 
+### Runtime Config for Local Development
+
+Local development on a JavaScript app typically does not include the [CNB lifecycle](#launching-the-server), and therefore misses the env-as-html-data runtime configuration behavior.
+
+This buildpack provides a [JS support module `@heroku/env-as-html-data`](../../support/env-as-html-data/) that can be integrated into an app's local dev server, so that configuration for local development matches production CNB-based deployment.
+
 ## Build-time Configuration
 
 _Static config that controls how the app is built, and how the web server delivers it._

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,729 @@
+{
+  "name": "frontend-web-support",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend-web-support",
+      "workspaces": [
+        "support/env-as-html-data"
+      ]
+    },
+    "node_modules/@heroku/env-as-html-data": {
+      "resolved": "support/env-as-html-data",
+      "link": true
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "12.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-12.0.0-rc.6.tgz",
+      "integrity": "sha512-JfQk/OfLIU+Ajm76oTYM5YZn7gHWUZZF9+V9FQhveAv4mnB5I0Qwmtqx6O8uWGwmK+rPaqCBPlXS5+mcmgYbKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^5.0.0",
+        "debug": "^4.3.5",
+        "diff": "^9.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.0",
+        "is-path-inside": "^3.0.3",
+        "is-unicode-supported": "^0.1.0",
+        "js-yaml": "^5.0.0",
+        "minimatch": "^10.2.2",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^7.0.2",
+        "strip-json-comments": "^5.0.3",
+        "supports-color": "^8.1.1",
+        "workerpool": "^10.0.0"
+      },
+      "bin": {
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-javascript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-10.0.3.tgz",
+      "integrity": "sha512-6z2Iis68Wqth93/G/wJP9u+R3O+d2XTlgWChGCwuT1qLbBsOYueGRZuJ++v3mtDP5KjYdy+WzvWC+VWETSVXJA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "support/env-as-html-data": {
+      "name": "@heroku/env-as-html-data",
+      "version": "2.0.0",
+      "license": "Apache License Version 2.0",
+      "dependencies": {
+        "cheerio": "^1.1.2"
+      },
+      "bin": {
+        "env-as-html-data": "bin/env-as-html-data"
+      },
+      "devDependencies": {
+        "mocha": "^12.0.0-beta.4"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -40,7 +39,6 @@
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -271,7 +269,6 @@
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -404,7 +401,6 @@
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
       "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -414,7 +410,6 @@
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
       "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.8"
@@ -430,7 +425,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -581,7 +575,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -660,6 +653,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/toml": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-5.0.0.tgz",
+      "integrity": "sha512-bsqEd+g7fzlrw7LEynQ6W6aOK/lTOlepz5x1sJyIV9fTZVJS2Q76nuju6FK+gZhW5bUpvB7mCEqdR0u4WziMFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/undici": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
@@ -716,7 +718,9 @@
       "version": "2.0.0",
       "license": "Apache License Version 2.0",
       "dependencies": {
-        "cheerio": "^1.1.2"
+        "cheerio": "^1.1.2",
+        "glob": "^13.0.6",
+        "toml": "^5.0.0"
       },
       "bin": {
         "env-as-html-data": "bin/env-as-html-data"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "frontend-web-support",
+  "private": true,
+  "workspaces": [
+    "support/env-as-html-data"
+  ]
+}

--- a/support/env-as-html-data/README.md
+++ b/support/env-as-html-data/README.md
@@ -28,7 +28,15 @@ html_files = ["index.html", "subsection/index.html"]
 
 By default, the module rewrites the configured index document, or `public/index.html` when no `project.toml` settings are present. Paths in `html_files` are relative to `root` and may include `*` or `**` glob patterns.
 
-Execute HTML injection with `npx env-as-html-data`.
+### Invoking env-to-html-data
+
+Invoke via CLI/shell with `npx env-as-html-data`.
+
+Or, import the module to invoke programmatically:
+```javascript
+const { injectEnvToHtmlFiles } = require('@heroku/env-to-html-data');
+await injectEnvToHtmlFiles();
+```
 
 ## Using Runtime Environment Variables
 
@@ -87,9 +95,11 @@ When this module runs during app start-up, it:
 
 ## Breaking Changes in v2.0
 
-Version 2.0.0 closely aligns the behavior of this module with the implementation in [`heroku/static-web-server`](../../buildpacks/static-web-server/README.md#runtime-app-configuration).
+Version 2.0.0 of this module closely aligns its behavior with the implementation in [`heroku/static-web-server`](../../buildpacks/static-web-server/README.md#runtime-app-configuration).
 
 + reads its own configuration from `project.toml` (instead of `ENV_AS_HTML_DATA_` env vars)
-+ reads env vars from with `PUBLIC_WEB_` prefix (instead of `PUBLIC_`)
++ reads env vars with `PUBLIC_WEB_` prefix (instead of `PUBLIC_`)
 + writes HTML Data attributes to `<head>` element (instead of `<body>`)
 + safely rewrites HTML files.
+
+All of this ensures that v2 behavior matches the Runtime Configuration behavior of `heroku/static-web-server` CNB, supporting local app dev without needing to run the full `pack build` and `docker run` CNB lifecycle.

--- a/support/env-as-html-data/README.md
+++ b/support/env-as-html-data/README.md
@@ -86,16 +86,14 @@ npm test --workspace @heroku/env-as-html-data
 
 ## How does the runtime variable injection work?
 
-When this module runs during app start-up, it:
+When injection is invoked:
 1. reads all `PUBLIC_WEB_*` environment variables
 2. reads `project.toml` to determine the document root and target HTML files
-3. updates the selected HTML files, writing these env vars as `<head data-*>` attributes
-4. leaves serving static files to the application's web server
-5. makes the head data attributes available within JavaScript and CSS running in the pages.
+3. rewrites the HTML files, injecting these env vars as `<head data-*>` attributes.
 
 ## Breaking Changes in v2.0
 
-Version 2.0.0 of this module closely aligns its behavior with the implementation in [`heroku/static-web-server`](../../buildpacks/static-web-server/README.md#runtime-app-configuration).
+Version 2.0 of this module closely aligns its behavior with the implementation in [`heroku/static-web-server`](../../buildpacks/static-web-server/README.md#runtime-app-configuration).
 
 + reads its own configuration from `project.toml` (instead of `ENV_AS_HTML_DATA_` env vars)
 + reads env vars with `PUBLIC_WEB_` prefix (instead of `PUBLIC_`)

--- a/support/env-as-html-data/README.md
+++ b/support/env-as-html-data/README.md
@@ -2,20 +2,31 @@
 
 *Supports local development of Front-end Web JavaScript apps, providing the same [runtime configuration strategy as the buildpacks/static web server](../../buildpacks/static-web-server/README.md#runtime-app-configuration), without requiring the local CNB `pack build` and `docker run` workflow for runtime configuration.*
 
-This module will inject the current environment variables as [HTML `data-*` global attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/data-*) into the app's HTML files. These variables can be updated everytime the app starts.
+This module injects the current environment variables as [HTML `data-*` global attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/data-*) into the app's HTML files. These variables can be updated every time the app starts.
+
+HTML files are parsed and serialized while updating the `<head>` element. This can normalize invalid HTML and reformat the document.
 
 ## Using this Module
 
-The general strategy to use this module in a JavaScript web app, is to invoke this module as part of the build process or immediately before dev server start-up.
+The general strategy to use this module in a JavaScript web app is to invoke it as part of the build process or immediately before dev-server start-up.
 
 Install to the JavaScript project:  
 ```shell
 npm install @heroku/env-as-html-data@">= 2.0.0"
 ```
 
-Configuration options (set as shell/environment variables):
-+ `ENV_AS_HTML_DATA_DIR` (default `public`) the directory to search for HTML files to process.
-+ `ENV_AS_HTML_DATA_FILE_EXT` (default `.html`) the file extension to match for files to process.
+Configure the target HTML files in the app's `project.toml`, using the same settings as [`heroku/static-web-server`](../../buildpacks/static-web-server/README.md#runtime-app-configuration):
+
+```toml
+[com.heroku.static-web-server]
+root = "public"
+index = "index.html"
+
+[com.heroku.static-web-server.runtime_config]
+html_files = ["index.html", "subsection/index.html"]
+```
+
+By default, the module rewrites the configured index document, or `public/index.html` when no `project.toml` settings are present. Paths in `html_files` are relative to `root` and may include `*` or `**` glob patterns.
 
 Execute HTML injection with `npx env-as-html-data`.
 
@@ -23,7 +34,7 @@ Execute HTML injection with `npx env-as-html-data`.
 
 **Do not set secret values into these environment variables.** They will be injected into the website, where anyone on the internet can see the values. As a precaution, only environment variables prefixed with `PUBLIC_WEB_` prefix will be exposed.
 
-**The variable names are case-insensitive, accessed as lowercase.** Although enviroment variables are colloquially uppercased, the resulting HTML Data Attributes are set & accessed lowercased, because [they are case-insensitive XML names](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/data-*).
+**Use uppercase `PUBLIC_WEB_` environment-variable names and access their HTML data attributes in lowercase.** Although environment variables are colloquially uppercased, the resulting HTML data attributes are set and accessed in lowercase because [they are case-insensitive XML names](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/data-*).
 
 For example, if this app is started:
 
@@ -34,17 +45,17 @@ export PORT=3000
 npm start
 ```
 
-When the app is loaded in the web browser's javascript environment, these can be accessed using the [HTML Data Attribtes](https://developer.mozilla.org/en-US/docs/Web/HTML/How_to/Use_data_attributes):
+When the app is loaded in the web browser's JavaScript environment, these can be accessed using the [HTML data attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/How_to/Use_data_attributes):
 
 ```javascript
-const body = document.querySelector("body")
+const head = document.head
 
 // These contain the env vars' values
-body.dataset.public_web_api_url
-body.dataset.public_web_release_version
+head.dataset.public_web_api_url
+head.dataset.public_web_release_version
 
 // PORT is not set, because it isn't prefixed with PUBLIC_WEB_
-body.dataset.port == null
+head.dataset.port == null
 ```
 
 ## Using Build-time Variables
@@ -69,6 +80,16 @@ npm test --workspace @heroku/env-as-html-data
 
 When this module runs during app start-up, it:
 1. reads all `PUBLIC_WEB_*` environment variables
-2. updates each `public/*.html` file, writing these env vars as `<body data-*>` attributes
-3. serves the `public/` directory as static files
-4. the body data attributes are available within javascript & CSS running in the pages.
+2. reads `project.toml` to determine the document root and target HTML files
+3. updates the selected HTML files, writing these env vars as `<head data-*>` attributes
+4. leaves serving static files to the application's web server
+5. makes the head data attributes available within JavaScript and CSS running in the pages.
+
+## Breaking Changes in v2.0
+
+Version 2.0.0 closely aligns the behavior of this module with the implementation in [`heroku/static-web-server`](../../buildpacks/static-web-server/README.md#runtime-app-configuration).
+
++ reads its own configuration from `project.toml` (instead of `ENV_AS_HTML_DATA_` env vars)
++ reads env vars from with `PUBLIC_WEB_` prefix (instead of `PUBLIC_`)
++ writes HTML Data attributes to `<head>` element (instead of `<body>`)
++ safely rewrites HTML files.

--- a/support/env-as-html-data/README.md
+++ b/support/env-as-html-data/README.md
@@ -30,7 +30,7 @@ By default, the module rewrites the configured index document, or `public/index.
 
 ### Invoking env-to-html-data
 
-Invoke via CLI/shell with `npx env-as-html-data`.
+Invoke via CLI/shell with `npx @heroku/env-as-html-data`.
 
 Or, import the module to invoke programmatically:
 ```javascript

--- a/support/env-as-html-data/README.md
+++ b/support/env-as-html-data/README.md
@@ -1,0 +1,74 @@
+# Javascript Module to Inject Environment Variables as HTML Data Attributes
+
+*Supports local development of Front-end Web JavaScript apps, providing the same [runtime configuration strategy as the buildpacks/static web server](../../buildpacks/static-web-server/README.md#runtime-app-configuration), without requiring the local CNB `pack build` and `docker run` workflow for runtime configuration.*
+
+This module will inject the current environment variables as [HTML `data-*` global attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/data-*) into the app's HTML files. These variables can be updated everytime the app starts.
+
+## Using this Module
+
+The general strategy to use this module in a JavaScript web app, is to invoke this module as part of the build process or immediately before dev server start-up.
+
+Install to the JavaScript project:  
+```shell
+npm install @heroku/env-as-html-data@">= 2.0.0"
+```
+
+Configuration options (set as shell/environment variables):
++ `ENV_AS_HTML_DATA_DIR` (default `public`) the directory to search for HTML files to process.
++ `ENV_AS_HTML_DATA_FILE_EXT` (default `.html`) the file extension to match for files to process.
+
+Execute HTML injection with `npx env-as-html-data`.
+
+## Using Runtime Environment Variables
+
+**Do not set secret values into these environment variables.** They will be injected into the website, where anyone on the internet can see the values. As a precaution, only environment variables prefixed with `PUBLIC_WEB_` prefix will be exposed.
+
+**The variable names are case-insensitive, accessed as lowercase.** Although enviroment variables are colloquially uppercased, the resulting HTML Data Attributes are set & accessed lowercased, because [they are case-insensitive XML names](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/data-*).
+
+For example, if this app is started:
+
+```
+export PUBLIC_WEB_API_URL=https://localhost:3001
+export PUBLIC_WEB_RELEASE_VERSION=v42
+export PORT=3000
+npm start
+```
+
+When the app is loaded in the web browser's javascript environment, these can be accessed using the [HTML Data Attribtes](https://developer.mozilla.org/en-US/docs/Web/HTML/How_to/Use_data_attributes):
+
+```javascript
+const body = document.querySelector("body")
+
+// These contain the env vars' values
+body.dataset.public_web_api_url
+body.dataset.public_web_release_version
+
+// PORT is not set, because it isn't prefixed with PUBLIC_WEB_
+body.dataset.port == null
+```
+
+## Using Build-time Variables
+
+Environment variables used to configure the build, such as Webpack configuration, should be accessed using the normal Node.js `process.env` object.
+
+## Development
+
+From the repository root, install the workspace dependencies:
+
+```bash
+npm install
+```
+
+Run this workspace's Mocha test suite:
+
+```bash
+npm test --workspace @heroku/env-as-html-data
+```
+
+## How does the runtime variable injection work?
+
+When this module runs during app start-up, it:
+1. reads all `PUBLIC_WEB_*` environment variables
+2. updates each `public/*.html` file, writing these env vars as `<body data-*>` attributes
+3. serves the `public/` directory as static files
+4. the body data attributes are available within javascript & CSS running in the pages.

--- a/support/env-as-html-data/bin/env-as-html-data
+++ b/support/env-as-html-data/bin/env-as-html-data
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const { injectEnvToHtmlFiles } = require('../index.js');
+
+const webroot = process.env.ENV_AS_HTML_DATA_DIR || 'public';
+const fileExt = process.env.ENV_AS_HTML_DATA_FILE_EXT || '.html';
+
+(async function envAsHtmlData() {
+  await injectEnvToHtmlFiles(process.env, webroot, fileExt);
+})();

--- a/support/env-as-html-data/bin/env-as-html-data
+++ b/support/env-as-html-data/bin/env-as-html-data
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 const { injectEnvToHtmlFiles } = require('../index.js');
 
-const webroot = process.env.ENV_AS_HTML_DATA_DIR || 'public';
-const fileExt = process.env.ENV_AS_HTML_DATA_FILE_EXT || '.html';
-
 (async function envAsHtmlData() {
-  await injectEnvToHtmlFiles(process.env, webroot, fileExt);
+  await injectEnvToHtmlFiles(process.env, process.cwd());
 })();

--- a/support/env-as-html-data/index.js
+++ b/support/env-as-html-data/index.js
@@ -1,0 +1,5 @@
+const injectEnvToHtmlFiles = require('./lib/inject-env-to-html-files.js');
+
+module.exports = {
+  injectEnvToHtmlFiles
+};

--- a/support/env-as-html-data/lib/inject-env-to-html-files.js
+++ b/support/env-as-html-data/lib/inject-env-to-html-files.js
@@ -1,0 +1,31 @@
+const fs = require('fs/promises');
+const path = require('path');
+const cheerio = require('cheerio');
+
+module.exports = async function injectEnvToHtmlFiles(env, dir, ext='.html') {
+  const publicEnv = Object
+    .entries(env)
+    .filter(([name, _]) => name.startsWith('PUBLIC_WEB_'));
+  
+  if (publicEnv.length < 1) {
+    return;
+  }
+  
+  const files = await fs.readdir(dir);
+  for (const file of files) {
+    const filepath = path.join(dir, file);
+    const stat = await fs.stat(filepath);
+    if(stat.isFile() && path.extname(file) === ext) {
+      const fileHandle = await fs.open(filepath, 'r+');
+      const contents = await fileHandle.readFile();
+      const document = cheerio.load(contents);
+      const bodyElement = document('body');
+
+      publicEnv.forEach(([envName, envValue]) => {
+        bodyElement.attr(`data-${envName.toLowerCase()}`, envValue);
+      });
+      await fileHandle.write(document.html(), 0);
+      await fileHandle.close();
+    }
+  }
+}

--- a/support/env-as-html-data/lib/inject-env-to-html-files.js
+++ b/support/env-as-html-data/lib/inject-env-to-html-files.js
@@ -30,14 +30,18 @@ module.exports = async function injectEnvToHtmlFiles(env, appDir) {
   for (const htmlFile of filePaths) {
     const filepath = path.join(documentRoot, htmlFile);
     const fileHandle = await fs.open(filepath, 'r+');
-    const contents = await fileHandle.readFile();
-    const document = cheerio.load(contents);
-    const headElement = document('head');
+    try {
+      const contents = await fileHandle.readFile();
+      const document = cheerio.load(contents);
+      const headElement = document('head');
 
-    publicEnv.forEach(([envName, envValue]) => {
-      headElement.attr(`data-${envName.toLowerCase()}`, envValue);
-    });
-    await fileHandle.write(document.html(), 0);
-    await fileHandle.close();
+      publicEnv.forEach(([envName, envValue]) => {
+        headElement.attr(`data-${envName.toLowerCase()}`, envValue);
+      });
+      await fileHandle.truncate(0);
+      await fileHandle.write(document.html(), 0);
+    } finally {
+      await fileHandle.close();
+    }
   }
 }

--- a/support/env-as-html-data/lib/inject-env-to-html-files.js
+++ b/support/env-as-html-data/lib/inject-env-to-html-files.js
@@ -1,31 +1,43 @@
 const fs = require('fs/promises');
 const path = require('path');
 const cheerio = require('cheerio');
+const { glob } = require('glob');
+const { loadRuntimeConfig } = require('./runtime-config.js');
 
-module.exports = async function injectEnvToHtmlFiles(env, dir, ext='.html') {
+module.exports = async function injectEnvToHtmlFiles(env, appDir) {
   const publicEnv = Object
     .entries(env)
     .filter(([name, _]) => name.startsWith('PUBLIC_WEB_'));
-  
+
   if (publicEnv.length < 1) {
     return;
   }
-  
-  const files = await fs.readdir(dir);
-  for (const file of files) {
-    const filepath = path.join(dir, file);
-    const stat = await fs.stat(filepath);
-    if(stat.isFile() && path.extname(file) === ext) {
-      const fileHandle = await fs.open(filepath, 'r+');
-      const contents = await fileHandle.readFile();
-      const document = cheerio.load(contents);
-      const bodyElement = document('body');
 
-      publicEnv.forEach(([envName, envValue]) => {
-        bodyElement.attr(`data-${envName.toLowerCase()}`, envValue);
-      });
-      await fileHandle.write(document.html(), 0);
-      await fileHandle.close();
+  const runtimeConfig = await loadRuntimeConfig(appDir);
+  if (!runtimeConfig.enabled) {
+    return;
+  }
+
+  const documentRoot = path.join(appDir, runtimeConfig.root);
+  const htmlFiles = runtimeConfig.htmlFiles || [runtimeConfig.index];
+  const filePaths = (await Promise.all(htmlFiles.map(async (htmlFile) => {
+    if (htmlFile.includes('*')) {
+      return glob(htmlFile, {cwd: documentRoot, nodir: true});
     }
+    return [htmlFile];
+  }))).flat();
+
+  for (const htmlFile of filePaths) {
+    const filepath = path.join(documentRoot, htmlFile);
+    const fileHandle = await fs.open(filepath, 'r+');
+    const contents = await fileHandle.readFile();
+    const document = cheerio.load(contents);
+    const headElement = document('head');
+
+    publicEnv.forEach(([envName, envValue]) => {
+      headElement.attr(`data-${envName.toLowerCase()}`, envValue);
+    });
+    await fileHandle.write(document.html(), 0);
+    await fileHandle.close();
   }
 }

--- a/support/env-as-html-data/lib/runtime-config.js
+++ b/support/env-as-html-data/lib/runtime-config.js
@@ -1,0 +1,30 @@
+const fs = require('fs/promises');
+const path = require('path');
+const toml = require('toml');
+
+const DEFAULT_DOCUMENT_ROOT = 'public';
+const DEFAULT_INDEX_DOCUMENT = 'index.html';
+
+async function loadRuntimeConfig(appDir) {
+  let contents;
+  try {
+    contents = await fs.readFile(path.join(appDir, 'project.toml'), 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      contents = '';
+    } else {
+      throw error;
+    }
+  }
+
+  const webServerConfig = toml.parse(contents).com?.heroku?.['static-web-server'] || {};
+  const runtimeConfig = webServerConfig.runtime_config || {};
+  return {
+    root: webServerConfig.root || DEFAULT_DOCUMENT_ROOT,
+    index: webServerConfig.index || DEFAULT_INDEX_DOCUMENT,
+    enabled: runtimeConfig.enabled ?? true,
+    htmlFiles: runtimeConfig.html_files
+  };
+}
+
+module.exports = { loadRuntimeConfig };

--- a/support/env-as-html-data/package.json
+++ b/support/env-as-html-data/package.json
@@ -16,7 +16,9 @@
   ],
   "license": "Apache License Version 2.0",
   "dependencies": {
-    "cheerio": "^1.1.2"
+    "cheerio": "^1.1.2",
+    "glob": "^13.0.6",
+    "toml": "^5.0.0"
   },
   "devDependencies": {
     "mocha": "^12.0.0-beta.4"

--- a/support/env-as-html-data/package.json
+++ b/support/env-as-html-data/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@heroku/env-as-html-data",
+  "version": "2.0.0",
+  "description": "Inject environment variables into HTML pages as data-* attributes.",
+  "main": "index.js",
+  "directories": {
+    "bin": "./bin"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "keywords": [
+    "html",
+    "javascript",
+    "environment"
+  ],
+  "license": "Apache License Version 2.0",
+  "dependencies": {
+    "cheerio": "^1.1.2"
+  },
+  "devDependencies": {
+    "mocha": "^12.0.0-beta.4"
+  }
+}

--- a/support/env-as-html-data/package.json
+++ b/support/env-as-html-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heroku/env-as-html-data",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Inject environment variables into HTML pages as data-* attributes.",
   "main": "index.js",
   "directories": {

--- a/support/env-as-html-data/test/fixtures/configured-directory/index.html
+++ b/support/env-as-html-data/test/fixtures/configured-directory/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <title>Configured directory page</title>
+</head>
+<body>
+  <h1>Configured directory page</h1>
+</body>
+</html>

--- a/support/env-as-html-data/test/fixtures/configured-extension/index.html
+++ b/support/env-as-html-data/test/fixtures/configured-extension/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <title>Default extension page</title>
+</head>
+<body>
+  <h1>Default extension page</h1>
+</body>
+</html>

--- a/support/env-as-html-data/test/fixtures/configured-extension/index.template
+++ b/support/env-as-html-data/test/fixtures/configured-extension/index.template
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <title>Configured extension page</title>
+</head>
+<body>
+  <h1>Configured extension page</h1>
+</body>
+</html>

--- a/support/env-as-html-data/test/fixtures/public/index.html
+++ b/support/env-as-html-data/test/fixtures/public/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>My test index page</title>
+</head>
+
+<body>
+  <h1>Test index page</h1>
+</body>
+
+</html>

--- a/support/env-as-html-data/test/fixtures/public/page-2.html
+++ b/support/env-as-html-data/test/fixtures/public/page-2.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>Test page 2</title>
+</head>
+
+<body>
+  <h1>Test page 2</h1>
+</body>
+
+</html>

--- a/support/env-as-html-data/test/inject-env-to-html-files-test.js
+++ b/support/env-as-html-data/test/inject-env-to-html-files-test.js
@@ -108,4 +108,16 @@ html_files = ["page-2.html", "subsection/**/*.html"]
     assert.equal((await loadDocument('public/index.html'))('head').attr('data-public_web_test'), undefined);
   });
 
+  it('truncates files after rewriting', async function () {
+    const filePath = path.join(testDir, 'public', 'index.html');
+    const original = await fs.readFile(filePath, 'utf8');
+    await fs.writeFile(filePath, `${original}${'x'.repeat(1000)}`);
+
+    await injectEnvToHtmlFiles({PUBLIC_WEB_TEST: 'shorter value'}, testDir);
+
+    const rewritten = await fs.readFile(filePath, 'utf8');
+    assert.equal(rewritten.endsWith('x'), false);
+    assert.doesNotThrow(() => cheerio.load(rewritten));
+  });
+
 });

--- a/support/env-as-html-data/test/inject-env-to-html-files-test.js
+++ b/support/env-as-html-data/test/inject-env-to-html-files-test.js
@@ -22,27 +22,26 @@ describe('injectEnvToHtmlFiles', function () {
     await fs.rm(testDir, {recursive: true});
   });
 
-  it('rewrites files with env variables set in body data-* attributes', async function () {
+  async function loadDocument(relativePath) {
+    return cheerio.load(await fs.readFile(path.join(testDir, relativePath)));
+  }
+
+  it('rewrites the default index document with env variables set in head data-* attributes', async function () {
     const testEnv = {
       PUBLIC_WEB_TEST: 'example value',
       PUBLIC_WEB_TEST_2: 'another value',
       SECRET_TEST: 'should not be exposed'
     };
-    await injectEnvToHtmlFiles(testEnv, path.join(testDir, 'public'));
+    await injectEnvToHtmlFiles(testEnv, testDir);
 
-    const expectedFiles = ['index.html', 'page-2.html'];
-    for (const filename of expectedFiles) {
-      const fileHandle = await fs.open(path.join(testDir, 'public', filename), 'r+');
-      const contents = await fileHandle.readFile();
-      const document = cheerio.load(contents);
-      await fileHandle.close();
-      const bodyElement = document('body');
-      const bodyAttrs = bodyElement.attr();
+    const indexDocument = await loadDocument('public/index.html');
+    const pageDocument = await loadDocument('public/page-2.html');
 
-      assert.equal(bodyAttrs['data-public_web_test'], 'example value', `PUBLIC_WEB_TEST env var is set incorrectly in ${filename}`);
-      assert.equal(bodyAttrs['data-public_web_test_2'], 'another value', `PUBLIC_WEB_TEST_2 env var is set incorrectly in ${filename}`);
-      assert.equal(bodyAttrs['data-secret_test'], null, `SECRET_TEST env var should not be set in ${filename}, because its name is not prefixed with PUBLIC_WEB_`);
-    }
+    assert.equal(indexDocument('head').attr('data-public_web_test'), 'example value');
+    assert.equal(indexDocument('head').attr('data-public_web_test_2'), 'another value');
+    assert.equal(indexDocument('head').attr('data-secret_test'), null);
+    assert.equal(indexDocument('body').attr('data-public_web_test'), undefined);
+    assert.equal(pageDocument('head').attr('data-public_web_test'), undefined);
   });
 
   it('without env variables leaves files untouched', async function () {
@@ -58,7 +57,7 @@ describe('injectEnvToHtmlFiles', function () {
       expectedFileHashes.push(createHash('sha256').update(contents).digest('base64'));
     }
 
-    await injectEnvToHtmlFiles(testEnv, path.join(testDir, 'public'));
+    await injectEnvToHtmlFiles(testEnv, testDir);
 
     for (const filename of expectedFiles) {
       const fileHandle = await fs.open(path.join(testDir, 'public', filename), 'r+');
@@ -70,46 +69,43 @@ describe('injectEnvToHtmlFiles', function () {
     assert.deepStrictEqual(resultFileHashes, expectedFileHashes);
   });
 
-  it('uses ENV_AS_HTML_DATA_DIR instead of the default public directory', async function () {
+  it('uses project.toml to configure the document root and index document', async function () {
+    await fs.writeFile(path.join(testDir, 'project.toml'), `
+[com.heroku.static-web-server]
+root = "configured-directory"
+index = "index.html"
+`);
+
     await execFileAsync(process.execPath, [executablePath], {
       cwd: testDir,
       env: {
         ...process.env,
-        ENV_AS_HTML_DATA_DIR: 'configured-directory',
         PUBLIC_WEB_TEST: 'configured directory value'
       }
     });
 
-    const configuredDocument = cheerio.load(
-      await fs.readFile(path.join(testDir, 'configured-directory', 'index.html'))
-    );
-    const defaultDocument = cheerio.load(
-      await fs.readFile(path.join(testDir, 'public', 'index.html'))
-    );
+    const configuredDocument = await loadDocument('configured-directory/index.html');
+    const defaultDocument = await loadDocument('public/index.html');
 
-    assert.equal(configuredDocument('body').attr('data-public_web_test'), 'configured directory value');
-    assert.equal(defaultDocument('body').attr('data-public_web_test'), undefined);
+    assert.equal(configuredDocument('head').attr('data-public_web_test'), 'configured directory value');
+    assert.equal(defaultDocument('head').attr('data-public_web_test'), undefined);
   });
 
-  it('uses ENV_AS_HTML_DATA_FILE_EXT to select files to process', async function () {
-    await execFileAsync(process.execPath, [executablePath], {
-      cwd: testDir,
-      env: {
-        ...process.env,
-        ENV_AS_HTML_DATA_DIR: 'configured-extension',
-        ENV_AS_HTML_DATA_FILE_EXT: '.template',
-        PUBLIC_WEB_TEST: 'configured extension value'
-      }
-    });
+  it('uses project.toml html_files with nested paths and globs', async function () {
+    await fs.mkdir(path.join(testDir, 'public', 'subsection', 'nested'), {recursive: true});
+    await fs.cp(path.join(testDir, 'public', 'index.html'), path.join(testDir, 'public', 'subsection', 'index.html'));
+    await fs.cp(path.join(testDir, 'public', 'index.html'), path.join(testDir, 'public', 'subsection', 'nested', 'page.html'));
+    await fs.writeFile(path.join(testDir, 'project.toml'), `
+[com.heroku.static-web-server.runtime_config]
+html_files = ["page-2.html", "subsection/**/*.html"]
+`);
 
-    const matchingDocument = cheerio.load(
-      await fs.readFile(path.join(testDir, 'configured-extension', 'index.template'))
-    );
-    const nonMatchingDocument = cheerio.load(
-      await fs.readFile(path.join(testDir, 'configured-extension', 'index.html'))
-    );
+    await injectEnvToHtmlFiles({PUBLIC_WEB_TEST: 'nested value'}, testDir);
 
-    assert.equal(matchingDocument('body').attr('data-public_web_test'), 'configured extension value');
-    assert.equal(nonMatchingDocument('body').attr('data-public_web_test'), undefined);
+    assert.equal((await loadDocument('public/page-2.html'))('head').attr('data-public_web_test'), 'nested value');
+    assert.equal((await loadDocument('public/subsection/index.html'))('head').attr('data-public_web_test'), 'nested value');
+    assert.equal((await loadDocument('public/subsection/nested/page.html'))('head').attr('data-public_web_test'), 'nested value');
+    assert.equal((await loadDocument('public/index.html'))('head').attr('data-public_web_test'), undefined);
   });
+
 });

--- a/support/env-as-html-data/test/inject-env-to-html-files-test.js
+++ b/support/env-as-html-data/test/inject-env-to-html-files-test.js
@@ -1,0 +1,67 @@
+const assert = require('assert');
+const fs = require('fs/promises');
+const path = require('path');
+const cheerio = require('cheerio');
+const { createHash } = require('crypto');
+const injectEnvToHtmlFiles = require('../lib/inject-env-to-html-files.js');
+
+describe('injectEnvToHtmlFiles', function () {
+  let testDir;
+
+  beforeEach(async function () {
+    testDir = await fs.mkdtemp('test_injectEnvToHtmlFiles_');
+    await fs.cp('test/fixtures/public', testDir, {recursive: true});
+  });
+
+  afterEach(async function () {
+    await fs.rm(testDir, {recursive: true});
+  });
+
+  it('rewrites files with env variables set in body data-* attributes', async function () {
+    const testEnv = {
+      PUBLIC_WEB_TEST: 'example value',
+      PUBLIC_WEB_TEST_2: 'another value',
+      SECRET_TEST: 'should not be exposed'
+    };
+    await injectEnvToHtmlFiles(testEnv, testDir);
+
+    const expectedFiles = ['index.html', 'page-2.html'];
+    for (const filename of expectedFiles) {
+      const fileHandle = await fs.open(path.join(testDir, filename), 'r+');
+      const contents = await fileHandle.readFile();
+      const document = cheerio.load(contents);
+      await fileHandle.close();
+      const bodyElement = document('body');
+      const bodyAttrs = bodyElement.attr();
+
+      assert.equal(bodyAttrs['data-public_web_test'], 'example value', `PUBLIC_WEB_TEST env var is set incorrectly in ${filename}`);
+      assert.equal(bodyAttrs['data-public_web_test_2'], 'another value', `PUBLIC_WEB_TEST_2 env var is set incorrectly in ${filename}`);
+      assert.equal(bodyAttrs['data-secret_test'], null, `SECRET_TEST env var should not be set in ${filename}, because its name is not prefixed with PUBLIC_WEB_`);
+    }
+  });
+
+  it('without env variables leaves files untouched', async function () {
+    const testEnv = {};
+    const expectedFiles = ['index.html', 'page-2.html'];
+    const expectedFileHashes = [];
+    const resultFileHashes = [];
+
+    for (const filename of expectedFiles) {
+      const fileHandle = await fs.open(path.join(testDir, filename), 'r+');
+      const contents = await fileHandle.readFile();
+      await fileHandle.close();
+      expectedFileHashes.push(createHash('sha256').update(contents).digest('base64'));
+    }
+
+    await injectEnvToHtmlFiles(testEnv, testDir);
+
+    for (const filename of expectedFiles) {
+      const fileHandle = await fs.open(path.join(testDir, filename), 'r+');
+      const contents = await fileHandle.readFile();
+      await fileHandle.close();
+      resultFileHashes.push(createHash('sha256').update(contents).digest('base64'));
+    }
+
+    assert.deepStrictEqual(resultFileHashes, expectedFileHashes);
+  });
+});

--- a/support/env-as-html-data/test/inject-env-to-html-files-test.js
+++ b/support/env-as-html-data/test/inject-env-to-html-files-test.js
@@ -1,16 +1,21 @@
 const assert = require('assert');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
 const fs = require('fs/promises');
 const path = require('path');
 const cheerio = require('cheerio');
 const { createHash } = require('crypto');
 const injectEnvToHtmlFiles = require('../lib/inject-env-to-html-files.js');
 
+const execFileAsync = promisify(execFile);
+const executablePath = path.resolve(__dirname, '../bin/env-as-html-data');
+
 describe('injectEnvToHtmlFiles', function () {
   let testDir;
 
   beforeEach(async function () {
     testDir = await fs.mkdtemp('test_injectEnvToHtmlFiles_');
-    await fs.cp('test/fixtures/public', testDir, {recursive: true});
+    await fs.cp('test/fixtures', testDir, {recursive: true});
   });
 
   afterEach(async function () {
@@ -23,11 +28,11 @@ describe('injectEnvToHtmlFiles', function () {
       PUBLIC_WEB_TEST_2: 'another value',
       SECRET_TEST: 'should not be exposed'
     };
-    await injectEnvToHtmlFiles(testEnv, testDir);
+    await injectEnvToHtmlFiles(testEnv, path.join(testDir, 'public'));
 
     const expectedFiles = ['index.html', 'page-2.html'];
     for (const filename of expectedFiles) {
-      const fileHandle = await fs.open(path.join(testDir, filename), 'r+');
+      const fileHandle = await fs.open(path.join(testDir, 'public', filename), 'r+');
       const contents = await fileHandle.readFile();
       const document = cheerio.load(contents);
       await fileHandle.close();
@@ -47,21 +52,64 @@ describe('injectEnvToHtmlFiles', function () {
     const resultFileHashes = [];
 
     for (const filename of expectedFiles) {
-      const fileHandle = await fs.open(path.join(testDir, filename), 'r+');
+      const fileHandle = await fs.open(path.join(testDir, 'public', filename), 'r+');
       const contents = await fileHandle.readFile();
       await fileHandle.close();
       expectedFileHashes.push(createHash('sha256').update(contents).digest('base64'));
     }
 
-    await injectEnvToHtmlFiles(testEnv, testDir);
+    await injectEnvToHtmlFiles(testEnv, path.join(testDir, 'public'));
 
     for (const filename of expectedFiles) {
-      const fileHandle = await fs.open(path.join(testDir, filename), 'r+');
+      const fileHandle = await fs.open(path.join(testDir, 'public', filename), 'r+');
       const contents = await fileHandle.readFile();
       await fileHandle.close();
       resultFileHashes.push(createHash('sha256').update(contents).digest('base64'));
     }
 
     assert.deepStrictEqual(resultFileHashes, expectedFileHashes);
+  });
+
+  it('uses ENV_AS_HTML_DATA_DIR instead of the default public directory', async function () {
+    await execFileAsync(process.execPath, [executablePath], {
+      cwd: testDir,
+      env: {
+        ...process.env,
+        ENV_AS_HTML_DATA_DIR: 'configured-directory',
+        PUBLIC_WEB_TEST: 'configured directory value'
+      }
+    });
+
+    const configuredDocument = cheerio.load(
+      await fs.readFile(path.join(testDir, 'configured-directory', 'index.html'))
+    );
+    const defaultDocument = cheerio.load(
+      await fs.readFile(path.join(testDir, 'public', 'index.html'))
+    );
+
+    assert.equal(configuredDocument('body').attr('data-public_web_test'), 'configured directory value');
+    assert.equal(defaultDocument('body').attr('data-public_web_test'), undefined);
+  });
+
+  it('uses ENV_AS_HTML_DATA_FILE_EXT to select files to process', async function () {
+    await execFileAsync(process.execPath, [executablePath], {
+      cwd: testDir,
+      env: {
+        ...process.env,
+        ENV_AS_HTML_DATA_DIR: 'configured-extension',
+        ENV_AS_HTML_DATA_FILE_EXT: '.template',
+        PUBLIC_WEB_TEST: 'configured extension value'
+      }
+    });
+
+    const matchingDocument = cheerio.load(
+      await fs.readFile(path.join(testDir, 'configured-extension', 'index.template'))
+    );
+    const nonMatchingDocument = cheerio.load(
+      await fs.readFile(path.join(testDir, 'configured-extension', 'index.html'))
+    );
+
+    assert.equal(matchingDocument('body').attr('data-public_web_test'), 'configured extension value');
+    assert.equal(nonMatchingDocument('body').attr('data-public_web_test'), undefined);
   });
 });


### PR DESCRIPTION
This PR is being superceded by https://github.com/heroku/buildpacks-frontend-web/pull/130 (using WASM).

-----

Currently, this buildpack's [Runtime Configuration](https://github.com/heroku/buildpacks-frontend-web/blob/main/buildpacks/static-web-server/README.md#runtime-app-configuration) system only applies to the app when [build and launched using CNB lifecycle](https://github.com/heroku/buildpacks-frontend-web/blob/main/buildpacks/static-web-server/README.md#launching-the-server), `pack build` and `docker run`. This unfortunately omits Runtime Config from inner loop, local, JavaScript development.

To support using Runtime Config (env-as-html-data) with local JS development, to match production deployment behavior, we're adding a JS module that provides matching behaviour. This module requires custom integration into local development toolchain using either a CLI/shell command or programmatic JS function call. We currently use it by way of a private Ember.js addon that injects env-as-html-data as part of the local dev server command.

This changeset pulls in the supporting JavaScript module `@heroku/env-as-html-data` source and revises to match this buildpack's [Runtime Configuration](https://github.com/heroku/buildpacks-frontend-web/blob/main/buildpacks/static-web-server/README.md#runtime-app-configuration) interface.