### PR TITLE
Fix inconsistent Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,10 +39,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      time: "12:00"
-      day: "sunday"
-      timezone: "America/Los_Angeles"
+      interval: "monthly"
     groups:
       javascript-dependencies:
         update-types:


### PR DESCRIPTION
Since we use a monthly schedule for all other ecosystems in this repo (and Languages repos in general) to reduce toil. Dependabot still opens PRs sooner for security updates.

(This was fixed in #129 after the review comment https://github.com/heroku/buildpacks-frontend-web/pull/129#discussion_r3828279583 , however, that fix wasn't ported over to #130 - the PR that ended up superseding it.)