### PR TITLE
ci: automate env-as-html-data releases

### DIFF
--- a/.github/release-configs/release-please-config.json
+++ b/.github/release-configs/release-please-config.json
@@ -1,0 +1,78 @@
+{
+  "packages": {
+    "support/env-as-html-data": {
+      "release-type": "node",
+      "version-file": "package.json",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": ["README.md"],
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "deps",
+          "scope": "dev",
+          "section": "Dependencies",
+          "hidden": true
+        },
+        {
+          "type": "deps",
+          "section": "Dependencies"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation",
+          "hidden": true
+        },
+        {
+          "type": "style",
+          "section": "Styles",
+          "hidden": true
+        },
+        {
+          "type": "chore",
+          "section": "Miscellaneous Chores",
+          "hidden": true
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": true
+        },
+        {
+          "type": "build",
+          "section": "Build System",
+          "hidden": true
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration",
+          "hidden": true
+        }
+      ]
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "plugins": [
+    "node-workspace"
+  ]
+}

--- a/.github/release-configs/release-please-manifest.json
+++ b/.github/release-configs/release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "support/env-as-html-data": "2.1.0"
+}

--- a/.github/workflows/check-env-as-html-data-release-scope.yml
+++ b/.github/workflows/check-env-as-html-data-release-scope.yml
@@ -1,0 +1,24 @@
+name: Check env-as-html-data release scope
+
+on:
+  pull_request:
+    paths:
+      - 'common/env_as_html_data/**'
+      - 'common/env_as_html_data_wasm/**'
+
+permissions:
+  contents: read
+
+jobs:
+  package-visible-change:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Require a package-visible change
+        run: |
+          if git diff --quiet "origin/${{ github.base_ref }}...HEAD" -- support/env-as-html-data; then
+            echo "::error::Changes to the env-as-html-data Rust implementation require a matching change under support/env-as-html-data so release-please can publish the package."
+            exit 1
+          fi

--- a/.github/workflows/check-env-as-html-data-release-scope.yml
+++ b/.github/workflows/check-env-as-html-data-release-scope.yml
@@ -18,7 +18,11 @@ jobs:
           fetch-depth: 0
       - name: Require a package-visible change
         run: |
-          if git diff --quiet "origin/${{ github.base_ref }}...HEAD" -- support/env-as-html-data; then
+          if git diff --quiet "origin/${{ github.base_ref }}...HEAD" -- \
+            support/env-as-html-data/index.js \
+            support/env-as-html-data/index.d.ts \
+            support/env-as-html-data/lib/ \
+            support/env-as-html-data/bin/; then
             echo "::error::Changes to the env-as-html-data Rust implementation require a matching change under support/env-as-html-data so release-please can publish the package."
             exit 1
           fi

--- a/.github/workflows/check-env-as-html-data-release-scope.yml
+++ b/.github/workflows/check-env-as-html-data-release-scope.yml
@@ -25,4 +25,10 @@ jobs:
             support/env-as-html-data/bin/; then
             echo "::error::Changes to the env-as-html-data Rust implementation require a matching change under support/env-as-html-data so release-please can publish the package."
             exit 1
+          else
+            status=$?
+            if [ "$status" -ne 1 ]; then
+              echo "::error::Unable to determine package-visible changes; git diff exited with status $status."
+              exit "$status"
+            fi
           fi

--- a/.github/workflows/release-env-as-html-data-on-push.yml
+++ b/.github/workflows/release-env-as-html-data-on-push.yml
@@ -1,0 +1,35 @@
+name: Publish env-as-html-data release
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  create-release:
+    runs-on: pub-hk-ubuntu-24.04-ip
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.DEV_TOOLS_RELEASE_WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - uses: actions/checkout@v7
+      - name: Checkout release workflows
+        uses: actions/checkout@v7
+        with:
+          repository: heroku/npm-release-workflows
+          token: ${{ steps.app-token.outputs.token }}
+          path: workflows-repo
+          ref: main
+      - name: Create GitHub release
+        uses: ./workflows-repo/.github/actions/release-on-push-create-release-public
+        with:
+          package-manager: npm
+          package-directory: support/env-as-html-data
+          branch_name: ${{ github.ref_name }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-env-as-html-data-on-push.yml
+++ b/.github/workflows/release-env-as-html-data-on-push.yml
@@ -18,6 +18,7 @@ jobs:
           app-id: ${{ vars.DEV_TOOLS_RELEASE_WORKFLOW_APP_ID }}
           private-key: ${{ secrets.DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }},npm-release-workflows
       - uses: actions/checkout@v7
       - name: Checkout release workflows
         uses: actions/checkout@v7

--- a/.github/workflows/release-env-as-html-data.yml
+++ b/.github/workflows/release-env-as-html-data.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   validate:
     runs-on: pub-hk-ubuntu-24.04-ip
+    permissions:
+      contents: read
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/release-env-as-html-data.yml
+++ b/.github/workflows/release-env-as-html-data.yml
@@ -1,0 +1,113 @@
+name: Release env-as-html-data
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Create or update the release PR without publishing to npm
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  validate:
+    runs-on: pub-hk-ubuntu-24.04-ip
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.DEV_TOOLS_RELEASE_WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - uses: actions/checkout@v7
+      - name: Checkout release workflows
+        uses: actions/checkout@v7
+        with:
+          repository: heroku/npm-release-workflows
+          token: ${{ steps.app-token.outputs.token }}
+          path: workflows-repo
+          ref: main
+      - name: Validate and test
+        uses: ./workflows-repo/.github/actions/release-validate-public
+        with:
+          package-manager: npm
+          package-directory: support/env-as-html-data
+          setup-command: rustup update && rustup target add wasm32-unknown-unknown && cargo install wasm-pack --version 0.15.0 --locked
+          lint_command: ''
+          test_command: test
+
+  release-please-pr:
+    needs: validate
+    runs-on: pub-hk-ubuntu-24.04-ip
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      npm_tag: ${{ steps.release.outputs.npm_tag }}
+      package_name: ${{ steps.release.outputs.package_name }}
+      pr_number: ${{ steps.release.outputs.pr_number }}
+      pr_already_exists: ${{ steps.release.outputs.pr_already_exists }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.DEV_TOOLS_RELEASE_WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - uses: actions/checkout@v7
+      - name: Checkout release workflows
+        uses: actions/checkout@v7
+        with:
+          repository: heroku/npm-release-workflows
+          token: ${{ steps.app-token.outputs.token }}
+          path: workflows-repo
+          ref: main
+      - name: Create release PR
+        id: release
+        uses: ./workflows-repo/.github/actions/release-please-pr-public
+        with:
+          package-manager: npm
+          package-directory: support/env-as-html-data
+          branch_name: ${{ github.ref_name }}
+          dry_run: ${{ inputs.dry_run }}
+          token: ${{ steps.app-token.outputs.token }}
+
+  publish:
+    needs: release-please-pr
+    if: needs.release-please-pr.outputs.pr_number != '' || needs.release-please-pr.outputs.pr_already_exists == 'true'
+    runs-on: pub-hk-ubuntu-24.04-ip
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.DEV_TOOLS_RELEASE_WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - uses: actions/checkout@v7
+      - name: Checkout release workflows
+        uses: actions/checkout@v7
+        with:
+          repository: heroku/npm-release-workflows
+          token: ${{ steps.app-token.outputs.token }}
+          path: workflows-repo
+          ref: main
+      - name: Publish to npm
+        uses: ./workflows-repo/.github/actions/release-publish-public
+        with:
+          package-manager: npm
+          package-directory: support/env-as-html-data
+          setup-command: rustup update && rustup target add wasm32-unknown-unknown && cargo install wasm-pack --version 0.15.0 --locked
+          workflows_token: ${{ steps.app-token.outputs.token }}
+          build_command: run build
+          dry_run: ${{ inputs.dry_run }}
+          npm_tag: ${{ needs.release-please-pr.outputs.npm_tag }}
+          package_name: ${{ needs.release-please-pr.outputs.package_name }}
+          pr_number: ${{ needs.release-please-pr.outputs.pr_number }}
+          branch_name: ${{ github.ref_name }}

--- a/.github/workflows/release-env-as-html-data.yml
+++ b/.github/workflows/release-env-as-html-data.yml
@@ -20,6 +20,7 @@ jobs:
           app-id: ${{ vars.DEV_TOOLS_RELEASE_WORKFLOW_APP_ID }}
           private-key: ${{ secrets.DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }},npm-release-workflows
       - uses: actions/checkout@v7
       - name: Checkout release workflows
         uses: actions/checkout@v7
@@ -56,6 +57,7 @@ jobs:
           app-id: ${{ vars.DEV_TOOLS_RELEASE_WORKFLOW_APP_ID }}
           private-key: ${{ secrets.DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }},npm-release-workflows
       - uses: actions/checkout@v7
       - name: Checkout release workflows
         uses: actions/checkout@v7
@@ -90,6 +92,7 @@ jobs:
           app-id: ${{ vars.DEV_TOOLS_RELEASE_WORKFLOW_APP_ID }}
           private-key: ${{ secrets.DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }},npm-release-workflows
       - uses: actions/checkout@v7
       - name: Checkout release workflows
         uses: actions/checkout@v7

--- a/.github/workflows/update-env-as-html-data-release-configs.yml
+++ b/.github/workflows/update-env-as-html-data-release-configs.yml
@@ -17,6 +17,7 @@ jobs:
           app-id: ${{ vars.DEV_TOOLS_RELEASE_WORKFLOW_APP_ID }}
           private-key: ${{ secrets.DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }},npm-release-workflows
       - uses: actions/checkout@v7
       - name: Checkout release workflows
         uses: actions/checkout@v7

--- a/.github/workflows/update-env-as-html-data-release-configs.yml
+++ b/.github/workflows/update-env-as-html-data-release-configs.yml
@@ -1,0 +1,31 @@
+name: Update env-as-html-data release configuration
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-configs:
+    runs-on: pub-hk-ubuntu-24.04-ip
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.DEV_TOOLS_RELEASE_WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - uses: actions/checkout@v7
+      - name: Checkout release workflows
+        uses: actions/checkout@v7
+        with:
+          repository: heroku/npm-release-workflows
+          token: ${{ steps.app-token.outputs.token }}
+          path: workflows-repo
+          ref: main
+      - name: Update release configuration
+        uses: ./workflows-repo/.github/actions/update-release-configs-job-public
+        with:
+          package-directory: support/env-as-html-data

--- a/release-channels.yml
+++ b/release-channels.yml
@@ -1,0 +1,5 @@
+channels:
+  main:
+    branch: main
+    prerelease: false
+    npm-tag: latest

--- a/support/env-as-html-data/CHANGELOG.md
+++ b/support/env-as-html-data/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2.1.0](https://github.com/heroku/buildpacks-frontend-web/releases/tag/env-as-html-data-v2.1.0) (2026-08-25)
+
+Initial release of the WebAssembly-backed package.

--- a/support/env-as-html-data/README.md
+++ b/support/env-as-html-data/README.md
@@ -138,12 +138,13 @@ All of this ensures that v2 behavior matches the Runtime Configuration behavior 
 
 ## Release process
 
-⚠️ _This manual process will be replaced with automated, trusted publishing._
+Releases are managed with [release-please](https://github.com/googleapis/release-please) and npm trusted publishing. Start the **Release env-as-html-data** GitHub Actions workflow from `main`. Use its `dry_run` input to create or update a release PR without publishing.
 
-Local build/package/release flow requires permissions for `@heroku` npm org.
+Release-please derives the next SemVer version from conventional commits that touch `support/env-as-html-data/`. Changes to the Rust implementation directories must include a corresponding package-visible change so they are eligible for an npm release:
 
-1. Update the version in `npm version X.Y.Z --workspace @heroku/env-as-html-data`.
-2. Commit this change (and push it to origin)
-3. Build the package: `npm run build --workspace @heroku/env-as-html-data`
-4. Publish: `npm publish --workspaces --access public --otp=XXXXXX`
-    1. include `--tag next` if a pre-release.
+- `common/env_as_html_data/`
+- `common/env_as_html_data_wasm/`
+
+After a non-dry run publishes the release PR's package version, merge the release PR. The push-triggered workflow creates the component-specific GitHub release and tag, `env-as-html-data-vX.Y.Z`.
+
+The trusted publisher must be configured in npm for `@heroku/env-as-html-data`, repository `heroku/buildpacks-frontend-web`, and workflow `.github/workflows/release-env-as-html-data.yml`.

--- a/support/env-as-html-data/package.json
+++ b/support/env-as-html-data/package.json
@@ -2,6 +2,15 @@
   "name": "@heroku/env-as-html-data",
   "version": "2.1.0",
   "description": "Inject environment variables into HTML pages as data-* attributes.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/heroku/buildpacks-frontend-web.git",
+    "directory": "support/env-as-html-data"
+  },
+  "homepage": "https://github.com/heroku/buildpacks-frontend-web/tree/main/support/env-as-html-data",
+  "bugs": {
+    "url": "https://github.com/heroku/buildpacks-frontend-web/issues"
+  },
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
@@ -20,6 +29,9 @@
     "test": "node --test"
   },
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "glob": "^13.0.6",
     "toml": "^5.0.0"


### PR DESCRIPTION
## Summary

- add public-repository release workflows for the `@heroku/env-as-html-data` npm workspace
- configure release-please to version only `support/env-as-html-data` and synchronize the root npm lockfile through its `node-workspace` plugin
- add package metadata, changelog, bootstrap state, and documentation for npm trusted publishing
- prevent Rust/WASM-only changes from bypassing the package-scoped release workflow

## Release Lifecycle

1. Dispatch **Release env-as-html-data** from `main`; use `dry_run` to create or update the release PR without publishing.
2. A non-dry run validates, builds, and publishes the version from the release PR branch using npm OIDC trusted publishing.
3. Merge the release PR; **Publish env-as-html-data release** creates the `env-as-html-data-vX.Y.Z` GitHub release.

## Validation

- `npm test --workspace @heroku/env-as-html-data`
- `npm pack --dry-run --json --workspace @heroku/env-as-html-data`
- YAML and release configuration JSON parsing
- `git diff --check`

The package test suite passes: 8 tests.

## Prerequisites Before Merge

- [x] Configure `DEV_TOOLS_RELEASE_WORKFLOW_APP_ID` and `DEV_TOOLS_RELEASE_WORKFLOW_APP_PRIVATE_KEY` for this repository.
- [x] Configure npm trusted publishing for `@heroku/env-as-html-data`, `heroku/buildpacks-frontend-web`, and `.github/workflows/release-env-as-html-data.yml`.
- [x] Create the initial `env-as-html-data-v2.1.0` GitHub release/tag at `4b441b8bbfa740b73b77ed566100caa3bd1d3fb2` ([done](https://github.com/heroku/buildpacks-frontend-web/releases/tag/env-as-html-data-v2.1.0)).

Depends on https://github.com/heroku/npm-release-workflows/pull/57, now merged as e3ab2403d1edef35420fd7b8b05f2a00c1eda579.